### PR TITLE
feat(api): implement blob-backed event store for query endpoints

### DIFF
--- a/crates/queue-keeper-api/src/handlers/webhook.rs
+++ b/crates/queue-keeper-api/src/handlers/webhook.rs
@@ -4,9 +4,8 @@
 //! `POST /webhook/{provider}`.
 
 use crate::{
-    queue_delivery::spawn_queue_delivery,
-    responses::store_wrapped_event_to_blob,
-    AppState, WebhookHandlerError, WebhookResponse,
+    queue_delivery::spawn_queue_delivery, responses::store_wrapped_event_to_blob, AppState,
+    WebhookHandlerError, WebhookResponse,
 };
 use axum::{
     extract::{Path, State},
@@ -167,7 +166,9 @@ pub async fn handle_provider_webhook(
             let storage = blob_storage.clone();
             let persist_event_id = event_id;
             tokio::spawn(async move {
-                if let Err(e) = store_wrapped_event_to_blob(storage.as_ref(), &event_to_persist).await {
+                if let Err(e) =
+                    store_wrapped_event_to_blob(storage.as_ref(), &event_to_persist).await
+                {
                     warn!(
                         event_id = %persist_event_id,
                         error = %e,

--- a/crates/queue-keeper-api/src/handlers/webhook.rs
+++ b/crates/queue-keeper-api/src/handlers/webhook.rs
@@ -3,7 +3,11 @@
 //! Exposes [`handle_provider_webhook`] which is registered at
 //! `POST /webhook/{provider}`.
 
-use crate::{queue_delivery::spawn_queue_delivery, AppState, WebhookHandlerError, WebhookResponse};
+use crate::{
+    queue_delivery::spawn_queue_delivery,
+    responses::store_wrapped_event_to_blob,
+    AppState, WebhookHandlerError, WebhookResponse,
+};
 use axum::{
     extract::{Path, State},
     http::HeaderMap,
@@ -15,7 +19,7 @@ use queue_keeper_core::{
     webhook::{ProcessingOutput, WebhookHeaders, WebhookRequest},
 };
 use std::collections::HashMap;
-use tracing::{error, info, instrument};
+use tracing::{error, info, instrument, warn};
 
 /// Handle a webhook for a specific provider.
 ///
@@ -154,6 +158,26 @@ pub async fn handle_provider_webhook(
     // Direct-mode events are forwarded as raw payloads and do not go through
     // the event router.
     if let ProcessingOutput::Wrapped(wrapped_event) = processing_output {
+        // Persist the wrapped event to blob storage so that /api/events queries
+        // return real data. This is fire-and-forget: a storage failure does not
+        // fail the webhook response — the event has already been enqueued for
+        // delivery. Storage errors are logged for investigation.
+        if let Some(ref blob_storage) = state.event_blob_storage {
+            let event_to_persist = wrapped_event.clone();
+            let storage = blob_storage.clone();
+            let persist_event_id = event_id;
+            tokio::spawn(async move {
+                if let Err(e) = store_wrapped_event_to_blob(storage.as_ref(), &event_to_persist).await {
+                    warn!(
+                        event_id = %persist_event_id,
+                        error = %e,
+                        "Failed to persist WrappedEvent to blob; \
+                         event was delivered but will not appear in /api/events"
+                    );
+                }
+            });
+        }
+
         if let Some(queue_client) = &state.queue_client {
             let handle = spawn_queue_delivery(
                 wrapped_event,

--- a/crates/queue-keeper-api/src/lib.rs
+++ b/crates/queue-keeper-api/src/lib.rs
@@ -33,6 +33,7 @@ use axum::{
 };
 use prometheus::TextEncoder;
 use queue_keeper_core::{
+    blob_storage::BlobStorage,
     bot_config::BotConfiguration,
     queue_integration::{DefaultEventRouter, EventRouter},
     EventId, SessionId, Timestamp,
@@ -125,6 +126,14 @@ pub struct AppState {
     /// In production, supply this via the `QK__SECURITY__ADMIN_API_KEY`
     /// environment variable.
     pub admin_api_key: Option<String>,
+
+    /// Blob storage used to persist [`WrappedEvent`] objects after processing.
+    ///
+    /// When `Some`, the webhook handler writes each successfully processed
+    /// event to this store so that `GET /api/events` and related endpoints
+    /// can return real data. When `None`, those endpoints return empty results
+    /// (development / testing mode with no storage configured).
+    pub event_blob_storage: Option<Arc<dyn BlobStorage>>,
 }
 
 impl AppState {
@@ -144,6 +153,7 @@ impl AppState {
         delivery_config: QueueDeliveryConfig,
         ip_rate_limiter: Option<Arc<IpFailureTracker>>,
         admin_api_key: Option<String>,
+        event_blob_storage: Option<Arc<dyn BlobStorage>>,
     ) -> Self {
         Self {
             config,
@@ -159,6 +169,7 @@ impl AppState {
             delivery_config,
             ip_rate_limiter,
             admin_api_key,
+            event_blob_storage,
         }
     }
 }
@@ -237,6 +248,7 @@ pub fn create_router(state: AppState) -> Router {
 }
 
 /// Start HTTP server
+#[allow(clippy::too_many_arguments)]
 pub async fn start_server(
     config: ServiceConfig,
     provider_registry: Arc<ProviderRegistry>,
@@ -245,6 +257,7 @@ pub async fn start_server(
     generic_provider_ids: HashSet<String>,
     queue_client: Option<Arc<dyn QueueClient>>,
     bot_config: Arc<BotConfiguration>,
+    event_blob_storage: Option<Arc<dyn BlobStorage>>,
 ) -> Result<(), ServiceError> {
     // Validate configuration before initializing any infrastructure
     config.validate().map_err(ServiceError::Configuration)?;
@@ -303,6 +316,7 @@ pub async fn start_server(
         QueueDeliveryConfig::default(),
         ip_rate_limiter,
         admin_api_key,
+        event_blob_storage,
     );
     let app = create_router(state);
 

--- a/crates/queue-keeper-api/src/lib.rs
+++ b/crates/queue-keeper-api/src/lib.rs
@@ -36,7 +36,7 @@ use queue_keeper_core::{
     blob_storage::BlobStorage,
     bot_config::BotConfiguration,
     queue_integration::{DefaultEventRouter, EventRouter},
-    EventId, SessionId, Timestamp,
+    EventId, QueueKeeperError, SessionId, Timestamp,
 };
 use queue_runtime::QueueClient;
 use std::{
@@ -413,9 +413,10 @@ async fn get_event(
 
     match state.event_store.get_event(&event_id).await {
         Ok(envelope) => Ok(Json(EventDetailResponse { event: envelope })),
+        Err(QueueKeeperError::NotFound { .. }) => Err(StatusCode::NOT_FOUND),
         Err(e) => {
             error!(error = %e, event_id = %event_id, "Failed to get event");
-            Err(StatusCode::NOT_FOUND)
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
     }
 }
@@ -452,9 +453,10 @@ async fn get_session(
 
     match state.event_store.get_session(&session_id).await {
         Ok(details) => Ok(Json(SessionDetailResponse { session: details })),
+        Err(QueueKeeperError::NotFound { .. }) => Err(StatusCode::NOT_FOUND),
         Err(e) => {
             error!(error = %e, session_id = %session_id, "Failed to get session");
-            Err(StatusCode::NOT_FOUND)
+            Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
     }
 }

--- a/crates/queue-keeper-api/src/lib_tests.rs
+++ b/crates/queue-keeper-api/src/lib_tests.rs
@@ -12,7 +12,11 @@ use queue_keeper_core::{
         NormalizationError, ProcessingOutput, StorageError, StorageReference, ValidationStatus,
         WebhookError, WebhookProcessor, WebhookRequest, WrappedEvent,
     },
-    Timestamp, ValidationError,
+    EventId, QueueKeeperError, SessionId, Timestamp, ValidationError,
+};
+use responses::{
+    EventListParams, EventListResponse, EventStore, SessionDetails, SessionListParams,
+    SessionListResponse, StatisticsResponse,
 };
 use std::sync::{Arc, Mutex, OnceLock};
 use tower::ServiceExt;
@@ -264,5 +268,131 @@ async fn test_unknown_provider_404_has_error_body() {
     assert!(
         body["error"].as_str().unwrap_or("").contains("nonexistent"),
         "Error message should mention the unknown provider name"
+    );
+}
+
+// ============================================================================
+// Event API handler tests
+// ============================================================================
+
+/// EventStore that always returns QueueKeeperError::Internal for get_event and get_session.
+struct AlwaysFailingEventStore;
+
+#[async_trait]
+impl EventStore for AlwaysFailingEventStore {
+    async fn list_events(
+        &self,
+        params: EventListParams,
+    ) -> Result<EventListResponse, QueueKeeperError> {
+        Ok(EventListResponse {
+            events: vec![],
+            total: 0,
+            page: params.page.unwrap_or(1),
+            per_page: params.per_page.unwrap_or(50),
+        })
+    }
+
+    async fn get_event(&self, _event_id: &EventId) -> Result<WrappedEvent, QueueKeeperError> {
+        Err(QueueKeeperError::Internal {
+            message: "simulated storage failure".to_string(),
+        })
+    }
+
+    async fn list_sessions(
+        &self,
+        _params: SessionListParams,
+    ) -> Result<SessionListResponse, QueueKeeperError> {
+        Ok(SessionListResponse {
+            sessions: vec![],
+            total: 0,
+        })
+    }
+
+    async fn get_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<SessionDetails, QueueKeeperError> {
+        Err(QueueKeeperError::Internal {
+            message: format!("simulated storage failure for {}", session_id),
+        })
+    }
+
+    async fn get_statistics(&self) -> Result<StatisticsResponse, QueueKeeperError> {
+        Ok(StatisticsResponse {
+            total_events: 0,
+            events_per_hour: 0.0,
+            active_sessions: 0,
+            error_rate: 0.0,
+            uptime_seconds: 0,
+        })
+    }
+}
+
+/// Build an [`AppState`] using a custom event store.
+fn test_app_state_with_store(store: impl EventStore + 'static) -> AppState {
+    AppState::new(
+        ServiceConfig::default(),
+        Arc::new(ProviderRegistry::new()),
+        Arc::new(DefaultHealthChecker),
+        Arc::new(store),
+        test_metrics(),
+        Arc::new(TelemetryConfig::new(
+            "test-service".to_string(),
+            "test".to_string(),
+        )),
+        std::collections::HashSet::new(),
+        None,
+        Arc::new(queue_keeper_core::queue_integration::DefaultEventRouter::new()),
+        Arc::new(queue_keeper_core::bot_config::BotConfiguration {
+            bots: vec![],
+            settings: queue_keeper_core::bot_config::BotConfigurationSettings::default(),
+        }),
+        queue_delivery::QueueDeliveryConfig::default(),
+        None,
+        None,
+        None,
+    )
+}
+
+/// GET /api/events/{event_id} must return 500 when the event store returns an
+/// Internal error (e.g. checksum mismatch), not 404.
+#[tokio::test]
+async fn test_get_event_returns_500_on_internal_error() {
+    let app = create_router(test_app_state_with_store(AlwaysFailingEventStore));
+
+    let event_id = EventId::new();
+    let request = Request::builder()
+        .method("GET")
+        .uri(format!("/api/events/{}", event_id))
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Internal storage errors must surface as 500, not 404"
+    );
+}
+
+/// GET /api/sessions/{session_id} must return 500 when the event store returns an
+/// Internal error, not 404.
+#[tokio::test]
+async fn test_get_session_returns_500_on_internal_error() {
+    let app = create_router(test_app_state_with_store(AlwaysFailingEventStore));
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/sessions/owner%2Frepo%2Fpull_request%2F1")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Internal storage errors must surface as 500, not 404"
     );
 }

--- a/crates/queue-keeper-api/src/lib_tests.rs
+++ b/crates/queue-keeper-api/src/lib_tests.rs
@@ -131,6 +131,7 @@ fn test_app_state(registry: ProviderRegistry) -> AppState {
         queue_delivery::QueueDeliveryConfig::default(),
         None, // ip_rate_limiter: disabled in unit tests
         None, // admin_api_key: no auth in unit tests
+        None, // event_blob_storage: no event persistence in unit tests
     )
 }
 

--- a/crates/queue-keeper-api/src/responses.rs
+++ b/crates/queue-keeper-api/src/responses.rs
@@ -727,6 +727,10 @@ impl EventStore for BlobBackedEventStore {
                 });
 
         // Apply in-memory filters (since, session_id) not supported at blob-list level.
+        // TODO: push the `since` cutoff down to the storage layer via
+        // `PayloadFilter.date_range` once that field is wired in the blob-storage
+        // implementations, eliminating the need to deserialise all blobs before
+        // filtering.
         let filtered: Vec<&WrappedEvent> = all_events
             .iter()
             .filter(|e| since_ts.is_none_or(|ts| e.received_at >= ts))
@@ -949,6 +953,12 @@ impl EventStore for BlobBackedEventStore {
         // Load all event bodies so we can count sessions accurately —
         // session_id is not stored in BlobMetadata so a metadata-only scan
         // (list_payloads) cannot determine the session count.
+        //
+        // NOTE: because load_all_events propagates ChecksumMismatch as
+        // QueueKeeperError::Internal, a single tampered or corrupt event blob
+        // will cause this endpoint to return 500 for every caller until the
+        // blob is removed. This is intentional: any tampering must be
+        // immediately visible rather than silently hidden behind partial stats.
         let all_events = self.load_all_events(&PayloadFilter::default()).await?;
 
         let total_events = all_events.len() as u64;

--- a/crates/queue-keeper-api/src/responses.rs
+++ b/crates/queue-keeper-api/src/responses.rs
@@ -450,6 +450,17 @@ impl HealthChecker for ServiceHealthChecker {
 /// Returns a [`BlobStorageError`] if serialisation or the underlying storage
 /// operation fails. The caller is expected to log the error and treat blob
 /// persistence failures as non-fatal (events are still delivered to queues).
+///
+/// # Storage Path Isolation
+///
+/// `WrappedEvent` blobs and raw-payload blobs (written by `BlobStorageAdapter`)
+/// share the same `webhook-payloads/…/{event_id}.json` path scheme. Path
+/// collisions are prevented by using **separate storage roots** — the call site
+/// must supply a [`BlobStorage`] instance backed by a different directory or
+/// container prefix than the one used for raw payloads. In the service binary
+/// this is enforced via `QK_EVENT_STORAGE_PATH`. `EventId` uniqueness means
+/// keys will never literally collide even if the wrong root is used, but
+/// blob metadata (event_type, repository) would be inconsistent between stores.
 pub async fn store_wrapped_event_to_blob(
     storage: &dyn BlobStorage,
     event: &WrappedEvent,
@@ -472,6 +483,9 @@ pub async fn store_wrapped_event_to_blob(
             event_id: event.event_id,
             event_type: event.event_type.clone(),
             repository,
+            // All WrappedEvents reaching this point have cleared webhook
+            // processing (including signature validation). The flag records
+            // validity at ingestion time; it is not re-checked on read.
             signature_valid: true,
             received_at: event.received_at,
             delivery_id: None,
@@ -496,7 +510,10 @@ fn extract_repository_from_wrapped_event(event: &WrappedEvent) -> Option<Reposit
     let id = repo_data.get("id")?.as_u64()?;
     let name = repo_data.get("name")?.as_str()?.to_string();
     let full_name = repo_data.get("full_name")?.as_str()?.to_string();
-    let private = repo_data.get("private").and_then(|p| p.as_bool()).unwrap_or(false);
+    let private = repo_data
+        .get("private")
+        .and_then(|p| p.as_bool())
+        .unwrap_or(false);
 
     let owner = repo_data.get("owner").and_then(|o| {
         let owner_id = o.get("id")?.as_u64()?;
@@ -578,7 +595,11 @@ impl BlobBackedEventStore {
                 resource: "event".to_string(),
                 id: event_id.to_string(),
             },
-            BlobStorageError::ChecksumMismatch { path, expected, actual } => {
+            BlobStorageError::ChecksumMismatch {
+                path,
+                expected,
+                actual,
+            } => {
                 error!(
                     path = %path,
                     expected_checksum = %expected,
@@ -649,6 +670,19 @@ impl BlobBackedEventStore {
                         "Blob listed but not found during load; may have been deleted"
                     );
                 }
+                Err(BlobStorageError::ChecksumMismatch { path, .. }) => {
+                    error!(
+                        event_id = %meta.event_id,
+                        path = %path,
+                        "Checksum mismatch for event blob — possible tampering detected"
+                    );
+                    return Err(QueueKeeperError::Internal {
+                        message: format!(
+                            "Checksum mismatch for event blob {}: possible tampering",
+                            meta.event_id
+                        ),
+                    });
+                }
                 Err(e) => {
                     warn!(event_id = %meta.event_id, error = %e, "Error loading event blob; skipping");
                 }
@@ -677,20 +711,34 @@ impl EventStore for BlobBackedEventStore {
 
         let all_events = self.load_all_events(&filter).await?;
 
-        // Apply session filter if provided (not a blob-level filter)
-        let filtered: Vec<&WrappedEvent> = if let Some(ref session_filter) = params.session_id {
-            all_events
-                .iter()
-                .filter(|e| {
+        // Parse `since` as an RFC 3339 timestamp. Invalid values are logged
+        // and treated as absent so callers receive a predictable result set
+        // rather than an opaque error.
+        let since_ts: Option<Timestamp> =
+            params
+                .since
+                .as_deref()
+                .and_then(|s| match Timestamp::from_rfc3339(s) {
+                    Ok(ts) => Some(ts),
+                    Err(_) => {
+                        warn!(since = %s, "Invalid 'since' timestamp format; ignoring filter");
+                        None
+                    }
+                });
+
+        // Apply in-memory filters (since, session_id) not supported at blob-list level.
+        let filtered: Vec<&WrappedEvent> = all_events
+            .iter()
+            .filter(|e| since_ts.is_none_or(|ts| e.received_at >= ts))
+            .filter(|e| {
+                params.session_id.as_deref().is_none_or(|s| {
                     e.session_id
                         .as_ref()
-                        .map(|s| s.as_str() == session_filter)
+                        .map(|id| id.as_str() == s)
                         .unwrap_or(false)
                 })
-                .collect()
-        } else {
-            all_events.iter().collect()
-        };
+            })
+            .collect();
 
         let total = filtered.len();
         let events = filtered
@@ -712,10 +760,7 @@ impl EventStore for BlobBackedEventStore {
         match self.storage.get_payload(event_id).await {
             Ok(Some(stored)) => serde_json::from_slice::<WrappedEvent>(&stored.payload.body)
                 .map_err(|e| QueueKeeperError::Internal {
-                    message: format!(
-                        "Failed to deserialise event {}: {}",
-                        event_id, e
-                    ),
+                    message: format!("Failed to deserialise event {}: {}", event_id, e),
                 }),
             Ok(None) => Err(QueueKeeperError::NotFound {
                 resource: "event".to_string(),
@@ -752,7 +797,7 @@ impl EventStore for BlobBackedEventStore {
 
         let mut sessions: Vec<SessionSummary> = session_map
             .iter()
-            .filter(|(sid, events)| {
+            .filter(|(sid, _events)| {
                 // entity_type filter: session_id format is owner/repo/entity_type/entity_id
                 if let Some(ref entity_type_filter) = params.entity_type {
                     let parts: Vec<&str> = sid.splitn(4, '/').collect();
@@ -760,11 +805,10 @@ impl EventStore for BlobBackedEventStore {
                         return false;
                     }
                 }
-                // status filter: we treat all sessions as "active" for now
+                // status filter: only "active" sessions are tracked; all stored
+                // sessions are considered active. Report nothing for any other status.
                 if let Some(ref status_filter) = params.status {
                     if status_filter != "active" {
-                        // Only "active" sessions are currently tracked
-                        let _ = events; // suppress unused warning
                         return false;
                     }
                 }
@@ -776,7 +820,10 @@ impl EventStore for BlobBackedEventStore {
                     .map(|e| e.received_at)
                     .max()
                     .unwrap_or_else(Timestamp::now);
-                let first_event = events[0];
+                // SAFETY: session_map entries always contain at least one event
+                let first_event = events
+                    .first()
+                    .expect("session group is non-empty by construction");
 
                 // Parse repo from session_id: owner/repo/entity_type/entity_id
                 let parts: Vec<&str> = sid.splitn(4, '/').collect();
@@ -789,10 +836,9 @@ impl EventStore for BlobBackedEventStore {
                 let entity_id = parts.get(3).copied().unwrap_or("0").to_string();
 
                 SessionSummary {
-                    session_id: first_event
-                        .session_id
-                        .clone()
-                        .unwrap_or_else(|| SessionId::from_parts("unknown", "unknown", "unknown", "0")),
+                    session_id: first_event.session_id.clone().unwrap_or_else(|| {
+                        SessionId::from_parts("unknown", "unknown", "unknown", "0")
+                    }),
                     repository,
                     entity_type,
                     entity_id,
@@ -801,12 +847,12 @@ impl EventStore for BlobBackedEventStore {
                     last_activity,
                 }
             })
-            .take(limit)
             .collect();
 
         sessions.sort_by(|a, b| b.last_activity.cmp(&a.last_activity));
 
-        let total = sessions.len();
+        let total = sessions.len(); // total before applying the limit
+        sessions.truncate(limit);
         Ok(SessionListResponse { sessions, total })
     }
 
@@ -855,32 +901,13 @@ impl EventStore for BlobBackedEventStore {
             .max()
             .unwrap_or_else(Timestamp::now);
 
-        // Build the Repository from the first event's payload or session_id parts
-        let first_event = session_events[0];
-        let repository = if let Some(full_name) = Self::repo_full_name(first_event) {
-            // Use the canonical Repository type from the payload when available
-            use queue_keeper_core::{Repository, RepositoryId, User, UserId, UserType};
-            let repo_data = first_event.payload.get("repository");
-            let id = repo_data
-                .and_then(|r| r.get("id"))
-                .and_then(|i| i.as_u64())
-                .unwrap_or(0);
-            let (owner_login, name) = full_name
-                .split_once('/')
-                .map(|(o, n)| (o.to_string(), n.to_string()))
-                .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
-            Repository::new(
-                RepositoryId::new(id),
-                name,
-                full_name,
-                User {
-                    id: UserId::new(0),
-                    login: owner_login,
-                    user_type: UserType::User,
-                },
-                false,
-            )
-        } else {
+        // SAFETY: session_events is non-empty — guarded by the is_empty check above
+        let first_event = session_events
+            .first()
+            .expect("session_events non-empty after is_empty guard");
+        // Use the shared helper for payload-based repository extraction; fall back
+        // to session_id parts when the payload lacks repository metadata.
+        let repository = extract_repository_from_wrapped_event(first_event).unwrap_or_else(|| {
             use queue_keeper_core::{Repository, RepositoryId, User, UserId, UserType};
             let (owner, repo) = if parts.len() >= 2 {
                 (parts[0].to_string(), parts[1].to_string())
@@ -898,10 +925,12 @@ impl EventStore for BlobBackedEventStore {
                 },
                 false,
             )
-        };
+        });
 
-        let event_summaries: Vec<EventSummary> =
-            session_events.iter().map(|e| Self::to_event_summary(e)).collect();
+        let event_summaries: Vec<EventSummary> = session_events
+            .iter()
+            .map(|e| Self::to_event_summary(e))
+            .collect();
 
         Ok(SessionDetails {
             session_id: session_id.clone(),
@@ -917,40 +946,37 @@ impl EventStore for BlobBackedEventStore {
     }
 
     async fn get_statistics(&self) -> Result<StatisticsResponse, QueueKeeperError> {
-        let all_events = self
-            .storage
-            .list_payloads(&PayloadFilter::default())
-            .await
-            .map_err(Self::map_storage_error)?;
+        // Load all event bodies so we can count sessions accurately —
+        // session_id is not stored in BlobMetadata so a metadata-only scan
+        // (list_payloads) cannot determine the session count.
+        let all_events = self.load_all_events(&PayloadFilter::default()).await?;
 
         let total_events = all_events.len() as u64;
 
-        // Estimate events per hour from oldest and newest timestamps
+        // Count distinct session IDs from the loaded event bodies.
+        let active_sessions = all_events
+            .iter()
+            .filter_map(|e| e.session_id.as_ref())
+            .collect::<std::collections::HashSet<_>>()
+            .len() as u64;
+
+        // Estimate events per hour from oldest and newest received_at timestamps.
         let events_per_hour = if total_events >= 2 {
-            let timestamps: Vec<Timestamp> =
-                all_events.iter().map(|m| m.created_at).collect();
-            let oldest = timestamps.iter().min().copied();
-            let newest = timestamps.iter().max().copied();
+            let oldest = all_events.iter().map(|e| e.received_at).min();
+            let newest = all_events.iter().map(|e| e.received_at).max();
             if let (Some(oldest), Some(newest)) = (oldest, newest) {
                 let span_secs = newest
                     .as_datetime()
                     .signed_duration_since(oldest.as_datetime())
                     .num_seconds()
                     .max(1) as f64;
-                let span_hours = span_secs / 3600.0;
-                (total_events as f64) / span_hours
+                (total_events as f64) / (span_secs / 3600.0)
             } else {
                 0.0
             }
         } else {
             0.0
         };
-
-        // Count unique session IDs from stored blob metadata event types
-        // (session_id is not in BlobMetadata, so we use a heuristic: assume
-        // "active sessions" ≈ distinct event counts within the last hour)
-        // A full count would require loading all bodies, which we avoid here.
-        let active_sessions = 0u64; // Conservative default without loading bodies
 
         let uptime_seconds = self.started_at.elapsed().as_secs();
 

--- a/crates/queue-keeper-api/src/responses.rs
+++ b/crates/queue-keeper-api/src/responses.rs
@@ -1,11 +1,16 @@
 //! Response types, query parameters, and supporting types for the API.
 
 use crate::ProviderRegistry;
+use queue_keeper_core::blob_storage::{
+    BlobStorage, BlobStorageError, PayloadFilter, PayloadMetadata, WebhookPayload,
+};
 use queue_keeper_core::webhook::WrappedEvent;
 use queue_keeper_core::{EventId, QueueKeeperError, Repository, SessionId, Timestamp};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
+use tracing::{debug, error, warn};
 
 // ============================================================================
 // Response Types
@@ -425,6 +430,537 @@ impl HealthChecker for ServiceHealthChecker {
         // An empty registry means the service cannot handle any incoming
         // webhooks, so Kubernetes should not route traffic to this pod.
         !self.provider_registry.is_empty()
+    }
+}
+
+// ============================================================================
+// Blob-Backed Event Store
+// ============================================================================
+
+/// Persist a [`WrappedEvent`] to blob storage so it can later be queried via
+/// [`BlobBackedEventStore`].
+///
+/// The event is serialised as JSON and wrapped in a synthetic [`WebhookPayload`]
+/// stored under the wrapped-event's own `event_id`. The blob storage
+/// implementation computes and persists a SHA-256 checksum at write time and
+/// verifies it on every read, providing tamper-evidence for free.
+///
+/// # Errors
+///
+/// Returns a [`BlobStorageError`] if serialisation or the underlying storage
+/// operation fails. The caller is expected to log the error and treat blob
+/// persistence failures as non-fatal (events are still delivered to queues).
+pub async fn store_wrapped_event_to_blob(
+    storage: &dyn BlobStorage,
+    event: &WrappedEvent,
+) -> Result<(), BlobStorageError> {
+    let body_json =
+        serde_json::to_vec(event).map_err(|e| BlobStorageError::SerializationFailed {
+            message: format!("Failed to serialise WrappedEvent {}: {}", event.event_id, e),
+        })?;
+
+    let body = bytes::Bytes::from(body_json);
+
+    // Extract repository from payload when available so that `list_payloads`
+    // repository filtering works correctly.
+    let repository = extract_repository_from_wrapped_event(event);
+
+    let payload = WebhookPayload {
+        body,
+        headers: HashMap::new(),
+        metadata: PayloadMetadata {
+            event_id: event.event_id,
+            event_type: event.event_type.clone(),
+            repository,
+            signature_valid: true,
+            received_at: event.received_at,
+            delivery_id: None,
+        },
+    };
+
+    storage
+        .store_payload(&event.event_id, &payload)
+        .await
+        .map(|_| ())
+}
+
+/// Extract repository information from a [`WrappedEvent`]'s JSON payload.
+///
+/// Returns `None` when the payload does not contain recognisable repository
+/// fields (e.g., non-GitHub providers).
+fn extract_repository_from_wrapped_event(event: &WrappedEvent) -> Option<Repository> {
+    use queue_keeper_core::{RepositoryId, User, UserId, UserType};
+
+    let repo_data = event.payload.get("repository")?;
+
+    let id = repo_data.get("id")?.as_u64()?;
+    let name = repo_data.get("name")?.as_str()?.to_string();
+    let full_name = repo_data.get("full_name")?.as_str()?.to_string();
+    let private = repo_data.get("private").and_then(|p| p.as_bool()).unwrap_or(false);
+
+    let owner = repo_data.get("owner").and_then(|o| {
+        let owner_id = o.get("id")?.as_u64()?;
+        let login = o.get("login")?.as_str()?.to_string();
+        let user_type = match o.get("type").and_then(|t| t.as_str()) {
+            Some("Organization") => UserType::Organization,
+            Some("Bot") => UserType::Bot,
+            _ => UserType::User,
+        };
+        Some(User {
+            id: UserId::new(owner_id),
+            login,
+            user_type,
+        })
+    })?;
+
+    Some(Repository::new(
+        RepositoryId::new(id),
+        name,
+        full_name,
+        owner,
+        private,
+    ))
+}
+
+/// Event store backed by blob storage.
+///
+/// Persisted [`WrappedEvent`] objects are read from the blob storage instance
+/// supplied at construction. Events must have been written there via
+/// [`store_wrapped_event_to_blob`] (called by the webhook handler after each
+/// successful processing pass).
+///
+/// # Session Queries
+///
+/// Sessions are derived by grouping events that share the same `session_id`.
+/// Listing sessions requires loading every stored event body, which is O(n)
+/// in the number of stored events. This is acceptable for the expected data
+/// volumes; a dedicated session index would be required at larger scale.
+///
+/// # Uptime Tracking
+///
+/// The store records the instant it was created so that `get_statistics` can
+/// report a meaningful `uptime_seconds` value.
+pub struct BlobBackedEventStore {
+    storage: Arc<dyn BlobStorage>,
+    started_at: Instant,
+}
+
+impl BlobBackedEventStore {
+    /// Create a new store wrapping the provided blob storage.
+    pub fn new(storage: Arc<dyn BlobStorage>) -> Self {
+        Self {
+            storage,
+            started_at: Instant::now(),
+        }
+    }
+
+    /// Deserialise a [`WrappedEvent`] from a [`StoredWebhook`] body.
+    fn deserialise_event(
+        stored: &queue_keeper_core::blob_storage::StoredWebhook,
+    ) -> Option<WrappedEvent> {
+        match serde_json::from_slice(&stored.payload.body) {
+            Ok(event) => Some(event),
+            Err(e) => {
+                warn!(
+                    event_id = %stored.metadata.event_id,
+                    error = %e,
+                    "Failed to deserialise WrappedEvent from blob; skipping"
+                );
+                None
+            }
+        }
+    }
+
+    /// Map a `BlobStorageError` onto the appropriate `QueueKeeperError`.
+    fn map_storage_error(err: BlobStorageError) -> QueueKeeperError {
+        match err {
+            BlobStorageError::BlobNotFound { event_id } => QueueKeeperError::NotFound {
+                resource: "event".to_string(),
+                id: event_id.to_string(),
+            },
+            BlobStorageError::ChecksumMismatch { path, expected, actual } => {
+                error!(
+                    path = %path,
+                    expected_checksum = %expected,
+                    actual_checksum = %actual,
+                    "Checksum mismatch detected — event data may be corrupted or tampered with"
+                );
+                QueueKeeperError::Internal {
+                    message: format!("Checksum mismatch for stored event at {path}"),
+                }
+            }
+            e => QueueKeeperError::ExternalService {
+                service: "blob_storage".to_string(),
+                message: e.to_string(),
+            },
+        }
+    }
+
+    /// Extract the repository full name from a [`WrappedEvent`]'s payload, if present.
+    fn repo_full_name(event: &WrappedEvent) -> Option<String> {
+        event
+            .payload
+            .get("repository")
+            .and_then(|r| r.get("full_name"))
+            .and_then(|f| f.as_str())
+            .map(str::to_string)
+    }
+
+    /// Convert a [`WrappedEvent`] into an [`EventSummary`].
+    fn to_event_summary(event: &WrappedEvent) -> EventSummary {
+        EventSummary {
+            event_id: event.event_id,
+            event_type: event.event_type.clone(),
+            repository: Self::repo_full_name(event).unwrap_or_else(|| "unknown".to_string()),
+            session_id: event
+                .session_id
+                .clone()
+                .unwrap_or_else(|| SessionId::from_parts("unknown", "unknown", "unknown", "0")),
+            occurred_at: event.received_at,
+            status: "processed".to_string(),
+        }
+    }
+
+    /// Load all stored events, deserialising each blob body.
+    ///
+    /// Blobs that fail to deserialise (e.g. raw webhook payloads accidentally
+    /// in the same storage) are silently skipped with a warning.
+    async fn load_all_events(
+        &self,
+        filter: &PayloadFilter,
+    ) -> Result<Vec<WrappedEvent>, QueueKeeperError> {
+        let blob_list = self
+            .storage
+            .list_payloads(filter)
+            .await
+            .map_err(Self::map_storage_error)?;
+
+        let mut events = Vec::with_capacity(blob_list.len());
+        for meta in blob_list {
+            match self.storage.get_payload(&meta.event_id).await {
+                Ok(Some(stored)) => {
+                    if let Some(event) = Self::deserialise_event(&stored) {
+                        events.push(event);
+                    }
+                }
+                Ok(None) => {
+                    debug!(
+                        event_id = %meta.event_id,
+                        "Blob listed but not found during load; may have been deleted"
+                    );
+                }
+                Err(e) => {
+                    warn!(event_id = %meta.event_id, error = %e, "Error loading event blob; skipping");
+                }
+            }
+        }
+
+        Ok(events)
+    }
+}
+
+#[async_trait::async_trait]
+impl EventStore for BlobBackedEventStore {
+    async fn list_events(
+        &self,
+        params: EventListParams,
+    ) -> Result<EventListResponse, QueueKeeperError> {
+        let page = params.page.unwrap_or(1).max(1);
+        let per_page = params.per_page.unwrap_or(50).clamp(1, 500);
+        let offset = (page - 1) * per_page;
+
+        let filter = PayloadFilter {
+            repository: params.repository.clone(),
+            event_type: params.event_type.clone(),
+            ..Default::default()
+        };
+
+        let all_events = self.load_all_events(&filter).await?;
+
+        // Apply session filter if provided (not a blob-level filter)
+        let filtered: Vec<&WrappedEvent> = if let Some(ref session_filter) = params.session_id {
+            all_events
+                .iter()
+                .filter(|e| {
+                    e.session_id
+                        .as_ref()
+                        .map(|s| s.as_str() == session_filter)
+                        .unwrap_or(false)
+                })
+                .collect()
+        } else {
+            all_events.iter().collect()
+        };
+
+        let total = filtered.len();
+        let events = filtered
+            .into_iter()
+            .skip(offset)
+            .take(per_page)
+            .map(Self::to_event_summary)
+            .collect();
+
+        Ok(EventListResponse {
+            events,
+            total,
+            page,
+            per_page,
+        })
+    }
+
+    async fn get_event(&self, event_id: &EventId) -> Result<WrappedEvent, QueueKeeperError> {
+        match self.storage.get_payload(event_id).await {
+            Ok(Some(stored)) => serde_json::from_slice::<WrappedEvent>(&stored.payload.body)
+                .map_err(|e| QueueKeeperError::Internal {
+                    message: format!(
+                        "Failed to deserialise event {}: {}",
+                        event_id, e
+                    ),
+                }),
+            Ok(None) => Err(QueueKeeperError::NotFound {
+                resource: "event".to_string(),
+                id: event_id.to_string(),
+            }),
+            Err(e) => Err(Self::map_storage_error(e)),
+        }
+    }
+
+    async fn list_sessions(
+        &self,
+        params: SessionListParams,
+    ) -> Result<SessionListResponse, QueueKeeperError> {
+        let filter = PayloadFilter {
+            repository: params.repository.clone(),
+            ..Default::default()
+        };
+
+        let all_events = self.load_all_events(&filter).await?;
+
+        // Group events by session_id
+        let mut session_map: HashMap<String, Vec<&WrappedEvent>> = HashMap::new();
+        for event in &all_events {
+            if let Some(ref sid) = event.session_id {
+                session_map
+                    .entry(sid.as_str().to_string())
+                    .or_default()
+                    .push(event);
+            }
+        }
+
+        // Apply entity_type filter if provided
+        let limit = params.limit.unwrap_or(usize::MAX);
+
+        let mut sessions: Vec<SessionSummary> = session_map
+            .iter()
+            .filter(|(sid, events)| {
+                // entity_type filter: session_id format is owner/repo/entity_type/entity_id
+                if let Some(ref entity_type_filter) = params.entity_type {
+                    let parts: Vec<&str> = sid.splitn(4, '/').collect();
+                    if parts.len() >= 3 && parts[2] != entity_type_filter {
+                        return false;
+                    }
+                }
+                // status filter: we treat all sessions as "active" for now
+                if let Some(ref status_filter) = params.status {
+                    if status_filter != "active" {
+                        // Only "active" sessions are currently tracked
+                        let _ = events; // suppress unused warning
+                        return false;
+                    }
+                }
+                true
+            })
+            .map(|(sid, events)| {
+                let last_activity = events
+                    .iter()
+                    .map(|e| e.received_at)
+                    .max()
+                    .unwrap_or_else(Timestamp::now);
+                let first_event = events[0];
+
+                // Parse repo from session_id: owner/repo/entity_type/entity_id
+                let parts: Vec<&str> = sid.splitn(4, '/').collect();
+                let repository = if parts.len() >= 2 {
+                    format!("{}/{}", parts[0], parts[1])
+                } else {
+                    "unknown/unknown".to_string()
+                };
+                let entity_type = parts.get(2).copied().unwrap_or("unknown").to_string();
+                let entity_id = parts.get(3).copied().unwrap_or("0").to_string();
+
+                SessionSummary {
+                    session_id: first_event
+                        .session_id
+                        .clone()
+                        .unwrap_or_else(|| SessionId::from_parts("unknown", "unknown", "unknown", "0")),
+                    repository,
+                    entity_type,
+                    entity_id,
+                    status: "active".to_string(),
+                    event_count: events.len() as u32,
+                    last_activity,
+                }
+            })
+            .take(limit)
+            .collect();
+
+        sessions.sort_by(|a, b| b.last_activity.cmp(&a.last_activity));
+
+        let total = sessions.len();
+        Ok(SessionListResponse { sessions, total })
+    }
+
+    async fn get_session(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<SessionDetails, QueueKeeperError> {
+        let all_events = self.load_all_events(&PayloadFilter::default()).await?;
+
+        let session_events: Vec<&WrappedEvent> = all_events
+            .iter()
+            .filter(|e| {
+                e.session_id
+                    .as_ref()
+                    .map(|s| s == session_id)
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        if session_events.is_empty() {
+            return Err(QueueKeeperError::NotFound {
+                resource: "session".to_string(),
+                id: session_id.to_string(),
+            });
+        }
+
+        // Parse repository from session_id: owner/repo/entity_type/entity_id
+        let sid_str = session_id.as_str();
+        let parts: Vec<&str> = sid_str.splitn(4, '/').collect();
+        let repo_full_name = if parts.len() >= 2 {
+            format!("{}/{}", parts[0], parts[1])
+        } else {
+            "unknown/unknown".to_string()
+        };
+        let entity_type = parts.get(2).copied().unwrap_or("unknown").to_string();
+        let entity_id = parts.get(3).copied().unwrap_or("0").to_string();
+
+        let created_at = session_events
+            .iter()
+            .map(|e| e.received_at)
+            .min()
+            .unwrap_or_else(Timestamp::now);
+        let last_activity = session_events
+            .iter()
+            .map(|e| e.received_at)
+            .max()
+            .unwrap_or_else(Timestamp::now);
+
+        // Build the Repository from the first event's payload or session_id parts
+        let first_event = session_events[0];
+        let repository = if let Some(full_name) = Self::repo_full_name(first_event) {
+            // Use the canonical Repository type from the payload when available
+            use queue_keeper_core::{Repository, RepositoryId, User, UserId, UserType};
+            let repo_data = first_event.payload.get("repository");
+            let id = repo_data
+                .and_then(|r| r.get("id"))
+                .and_then(|i| i.as_u64())
+                .unwrap_or(0);
+            let (owner_login, name) = full_name
+                .split_once('/')
+                .map(|(o, n)| (o.to_string(), n.to_string()))
+                .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
+            Repository::new(
+                RepositoryId::new(id),
+                name,
+                full_name,
+                User {
+                    id: UserId::new(0),
+                    login: owner_login,
+                    user_type: UserType::User,
+                },
+                false,
+            )
+        } else {
+            use queue_keeper_core::{Repository, RepositoryId, User, UserId, UserType};
+            let (owner, repo) = if parts.len() >= 2 {
+                (parts[0].to_string(), parts[1].to_string())
+            } else {
+                ("unknown".to_string(), "unknown".to_string())
+            };
+            Repository::new(
+                RepositoryId::new(0),
+                repo.clone(),
+                repo_full_name.clone(),
+                User {
+                    id: UserId::new(0),
+                    login: owner,
+                    user_type: UserType::User,
+                },
+                false,
+            )
+        };
+
+        let event_summaries: Vec<EventSummary> =
+            session_events.iter().map(|e| Self::to_event_summary(e)).collect();
+
+        Ok(SessionDetails {
+            session_id: session_id.clone(),
+            repository,
+            entity_type,
+            entity_id,
+            status: "active".to_string(),
+            created_at,
+            last_activity,
+            event_count: event_summaries.len() as u32,
+            events: event_summaries,
+        })
+    }
+
+    async fn get_statistics(&self) -> Result<StatisticsResponse, QueueKeeperError> {
+        let all_events = self
+            .storage
+            .list_payloads(&PayloadFilter::default())
+            .await
+            .map_err(Self::map_storage_error)?;
+
+        let total_events = all_events.len() as u64;
+
+        // Estimate events per hour from oldest and newest timestamps
+        let events_per_hour = if total_events >= 2 {
+            let timestamps: Vec<Timestamp> =
+                all_events.iter().map(|m| m.created_at).collect();
+            let oldest = timestamps.iter().min().copied();
+            let newest = timestamps.iter().max().copied();
+            if let (Some(oldest), Some(newest)) = (oldest, newest) {
+                let span_secs = newest
+                    .as_datetime()
+                    .signed_duration_since(oldest.as_datetime())
+                    .num_seconds()
+                    .max(1) as f64;
+                let span_hours = span_secs / 3600.0;
+                (total_events as f64) / span_hours
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+
+        // Count unique session IDs from stored blob metadata event types
+        // (session_id is not in BlobMetadata, so we use a heuristic: assume
+        // "active sessions" ≈ distinct event counts within the last hour)
+        // A full count would require loading all bodies, which we avoid here.
+        let active_sessions = 0u64; // Conservative default without loading bodies
+
+        let uptime_seconds = self.started_at.elapsed().as_secs();
+
+        Ok(StatisticsResponse {
+            total_events,
+            events_per_hour,
+            active_sessions,
+            error_rate: 0.0,
+            uptime_seconds,
+        })
     }
 }
 

--- a/crates/queue-keeper-api/src/responses_tests.rs
+++ b/crates/queue-keeper-api/src/responses_tests.rs
@@ -623,4 +623,124 @@ mod blob_backed_event_store_tests {
 
         let _ = std::fs::remove_dir_all(dir);
     }
+
+    /// `list_events` with a `since` filter returns only events received after the cutoff.
+    #[tokio::test]
+    async fn test_list_events_filters_by_since() {
+        use queue_keeper_core::Timestamp;
+        use std::time::Duration;
+
+        let (storage, dir) = make_storage("list-events-since").await;
+        let store = BlobBackedEventStore::new(Arc::clone(&storage));
+
+        // Store 2 events, then record a timestamp, then store 1 more event
+        for _ in 0..2 {
+            let e = WrappedEvent::new(
+                "github".to_string(),
+                "push".to_string(),
+                None,
+                None,
+                serde_json::json!({}),
+            );
+            store_wrapped_event_to_blob(storage.as_ref(), &e)
+                .await
+                .unwrap();
+        }
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let cutoff = Timestamp::now();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let e = WrappedEvent::new(
+            "github".to_string(),
+            "push".to_string(),
+            None,
+            None,
+            serde_json::json!({}),
+        );
+        store_wrapped_event_to_blob(storage.as_ref(), &e)
+            .await
+            .unwrap();
+
+        let params = EventListParams {
+            page: None,
+            per_page: None,
+            event_type: None,
+            repository: None,
+            session_id: None,
+            since: Some(cutoff.to_rfc3339()),
+        };
+        let response = store.list_events(params).await.unwrap();
+
+        assert_eq!(
+            response.total, 1,
+            "only the event after the cutoff should be returned"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `list_sessions` with a limit must return the most-recently-active sessions,
+    /// not an arbitrary subset limited before sorting.
+    #[tokio::test]
+    async fn test_list_sessions_limit_returns_most_recent() {
+        use std::time::Duration;
+
+        let (storage, dir) = make_storage("list-sessions-limit").await;
+        let store = BlobBackedEventStore::new(Arc::clone(&storage));
+
+        // Store session A first (oldest), then B (newest)
+        let session_a = SessionId::from_parts("owner", "repo", "issues", "1");
+        let session_b = SessionId::from_parts("owner", "repo", "issues", "2");
+
+        let e_a = WrappedEvent::new(
+            "github".to_string(),
+            "issues".to_string(),
+            None,
+            Some(session_a.clone()),
+            serde_json::json!({}),
+        );
+        store_wrapped_event_to_blob(storage.as_ref(), &e_a)
+            .await
+            .unwrap();
+
+        // Ensure session B has a clearly later timestamp
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let e_b = WrappedEvent::new(
+            "github".to_string(),
+            "issues".to_string(),
+            None,
+            Some(session_b.clone()),
+            serde_json::json!({}),
+        );
+        store_wrapped_event_to_blob(storage.as_ref(), &e_b)
+            .await
+            .unwrap();
+
+        // Request only 1 session — must be the most-recently-active one (session B)
+        let params = SessionListParams {
+            repository: None,
+            entity_type: None,
+            status: None,
+            limit: Some(1),
+        };
+        let response = store.list_sessions(params).await.unwrap();
+
+        assert_eq!(
+            response.sessions.len(),
+            1,
+            "limit=1 must return exactly 1 session"
+        );
+        assert_eq!(
+            response.sessions[0].session_id, session_b,
+            "the most recently active session must be returned when limit=1"
+        );
+        assert_eq!(
+            response.total, 2,
+            "total includes all sessions before the limit"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }

--- a/crates/queue-keeper-api/src/responses_tests.rs
+++ b/crates/queue-keeper-api/src/responses_tests.rs
@@ -225,3 +225,402 @@ mod service_health_checker_tests {
         );
     }
 }
+
+// ============================================================================
+// BlobBackedEventStore tests
+// ============================================================================
+
+mod blob_backed_event_store_tests {
+    use crate::responses::{
+        store_wrapped_event_to_blob, BlobBackedEventStore, EventListParams, EventStore,
+        SessionListParams,
+    };
+    use queue_keeper_core::adapters::filesystem_storage::FilesystemBlobStorage;
+    use queue_keeper_core::blob_storage::BlobStorage;
+    use queue_keeper_core::webhook::WrappedEvent;
+    use queue_keeper_core::SessionId;
+    use std::sync::Arc;
+
+    /// Helper: construct an in-temp-dir `Arc<dyn BlobStorage>` for a named test.
+    async fn make_storage(test_name: &str) -> (Arc<dyn BlobStorage>, std::path::PathBuf) {
+        let path = std::env::temp_dir().join(format!("qk-event-store-test-{}", test_name));
+        let _ = std::fs::remove_dir_all(&path);
+        let storage: Arc<dyn BlobStorage> = Arc::new(
+            FilesystemBlobStorage::new(path.clone())
+                .await
+                .expect("FilesystemBlobStorage::new must succeed"),
+        );
+        (storage, path)
+    }
+
+    /// Store one event and retrieve it back.
+    ///
+    /// Verifies that `store_wrapped_event_to_blob` + `BlobBackedEventStore::get_event`
+    /// round-trips correctly, including event_id, event_type, and provider fields.
+    #[tokio::test]
+    async fn test_get_event_round_trips() {
+        let (storage, dir) = make_storage("get-event").await;
+        let store = BlobBackedEventStore::new(Arc::clone(&storage));
+
+        let event = WrappedEvent::new(
+            "github".to_string(),
+            "push".to_string(),
+            None,
+            None,
+            serde_json::json!({}),
+        );
+        let event_id = event.event_id;
+
+        store_wrapped_event_to_blob(storage.as_ref(), &event)
+            .await
+            .expect("store must succeed");
+
+        let retrieved = store
+            .get_event(&event_id)
+            .await
+            .expect("get_event must succeed");
+
+        assert_eq!(retrieved.event_id, event_id);
+        assert_eq!(retrieved.event_type, "push");
+        assert_eq!(retrieved.provider, "github");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `get_event` returns `QueueKeeperError::NotFound` for unknown event IDs.
+    #[tokio::test]
+    async fn test_get_event_not_found_returns_error() {
+        let (storage, dir) = make_storage("get-event-not-found").await;
+        let store = BlobBackedEventStore::new(storage);
+
+        let nonexistent = queue_keeper_core::EventId::new();
+        let result = store.get_event(&nonexistent).await;
+
+        assert!(result.is_err(), "must return error for unknown event");
+        assert!(
+            matches!(
+                result.unwrap_err(),
+                queue_keeper_core::QueueKeeperError::NotFound { .. }
+            ),
+            "error must be NotFound"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `list_events` returns all stored events with correct pagination.
+    #[tokio::test]
+    async fn test_list_events_returns_stored_events() {
+        let (storage, dir) = make_storage("list-events").await;
+        let store = BlobBackedEventStore::new(Arc::clone(&storage));
+
+        // Store 3 push events
+        for _ in 0..3 {
+            let e = WrappedEvent::new(
+                "github".to_string(),
+                "push".to_string(),
+                None,
+                None,
+                serde_json::json!({}),
+            );
+            store_wrapped_event_to_blob(storage.as_ref(), &e)
+                .await
+                .expect("store must succeed");
+        }
+
+        let params = EventListParams {
+            page: None,
+            per_page: None,
+            event_type: None,
+            repository: None,
+            session_id: None,
+            since: None,
+        };
+        let response = store
+            .list_events(params)
+            .await
+            .expect("list_events must succeed");
+
+        assert_eq!(response.total, 3, "must return 3 stored events");
+        assert_eq!(response.events.len(), 3);
+        assert!(response.events.iter().all(|e| e.event_type == "push"));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `list_events` with `event_type` filter returns only matching events.
+    #[tokio::test]
+    async fn test_list_events_filters_by_event_type() {
+        let (storage, dir) = make_storage("list-events-filter").await;
+        let store = BlobBackedEventStore::new(Arc::clone(&storage));
+
+        // Store 2 push + 1 pull_request
+        for event_type in &["push", "push", "pull_request"] {
+            let e = WrappedEvent::new(
+                "github".to_string(),
+                event_type.to_string(),
+                None,
+                None,
+                serde_json::json!({}),
+            );
+            store_wrapped_event_to_blob(storage.as_ref(), &e)
+                .await
+                .unwrap();
+        }
+
+        let params = EventListParams {
+            event_type: Some("pull_request".to_string()),
+            page: None,
+            per_page: None,
+            repository: None,
+            session_id: None,
+            since: None,
+        };
+        let response = store.list_events(params).await.unwrap();
+
+        assert_eq!(
+            response.total, 1,
+            "only pull_request events should be returned"
+        );
+        assert_eq!(response.events[0].event_type, "pull_request");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `list_events` pagination: page 2 with per_page=1 returns the second event.
+    #[tokio::test]
+    async fn test_list_events_pagination() {
+        let (storage, dir) = make_storage("list-events-page").await;
+        let store = BlobBackedEventStore::new(Arc::clone(&storage));
+
+        for _ in 0..3 {
+            let e = WrappedEvent::new(
+                "github".to_string(),
+                "push".to_string(),
+                None,
+                None,
+                serde_json::json!({}),
+            );
+            store_wrapped_event_to_blob(storage.as_ref(), &e)
+                .await
+                .unwrap();
+        }
+
+        let params = EventListParams {
+            page: Some(1),
+            per_page: Some(2),
+            event_type: None,
+            repository: None,
+            session_id: None,
+            since: None,
+        };
+        let response = store.list_events(params).await.unwrap();
+
+        assert_eq!(response.total, 3, "total must include all events");
+        assert_eq!(
+            response.events.len(),
+            2,
+            "per_page=2 → only 2 items returned"
+        );
+        assert_eq!(response.page, 1);
+        assert_eq!(response.per_page, 2);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `list_sessions` groups events by session_id.
+    #[tokio::test]
+    async fn test_list_sessions_groups_by_session_id() {
+        let (storage, dir) = make_storage("list-sessions").await;
+        let store = BlobBackedEventStore::new(Arc::clone(&storage));
+
+        let session_a = SessionId::from_parts("owner", "repo", "pull_request", "1");
+        let session_b = SessionId::from_parts("owner", "repo", "pull_request", "2");
+
+        // 2 events on session A, 1 event on session B
+        for session in [&session_a, &session_a, &session_b] {
+            let e = WrappedEvent::new(
+                "github".to_string(),
+                "pull_request".to_string(),
+                Some("opened".to_string()),
+                Some(session.clone()),
+                serde_json::json!({}),
+            );
+            store_wrapped_event_to_blob(storage.as_ref(), &e)
+                .await
+                .unwrap();
+        }
+
+        let params = SessionListParams {
+            repository: None,
+            entity_type: None,
+            status: None,
+            limit: None,
+        };
+        let response = store.list_sessions(params).await.unwrap();
+
+        assert_eq!(response.total, 2, "must return 2 distinct sessions");
+
+        let session_a_summary = response
+            .sessions
+            .iter()
+            .find(|s| s.session_id == session_a)
+            .expect("session A must be present");
+        assert_eq!(session_a_summary.event_count, 2, "session A has 2 events");
+        assert_eq!(
+            response
+                .sessions
+                .iter()
+                .find(|s| s.session_id == session_b)
+                .unwrap()
+                .event_count,
+            1
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `get_session` returns all events for a known session.
+    #[tokio::test]
+    async fn test_get_session_returns_session_details() {
+        let (storage, dir) = make_storage("get-session").await;
+        let store = BlobBackedEventStore::new(Arc::clone(&storage));
+
+        let session = SessionId::from_parts("owner", "myrepo", "pull_request", "42");
+
+        for action in &["opened", "synchronize"] {
+            let e = WrappedEvent::new(
+                "github".to_string(),
+                "pull_request".to_string(),
+                Some(action.to_string()),
+                Some(session.clone()),
+                serde_json::json!({}),
+            );
+            store_wrapped_event_to_blob(storage.as_ref(), &e)
+                .await
+                .unwrap();
+        }
+
+        let details = store
+            .get_session(&session)
+            .await
+            .expect("get_session must succeed");
+
+        assert_eq!(details.session_id, session);
+        assert_eq!(details.event_count, 2);
+        assert_eq!(details.entity_type, "pull_request");
+        assert_eq!(details.entity_id, "42");
+        assert_eq!(details.events.len(), 2);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `get_session` returns `NotFound` for an unknown session.
+    #[tokio::test]
+    async fn test_get_session_not_found() {
+        let (storage, dir) = make_storage("get-session-missing").await;
+        let store = BlobBackedEventStore::new(storage);
+
+        let missing_session = SessionId::from_parts("x", "y", "issues", "999");
+        let result = store.get_session(&missing_session).await;
+
+        assert!(result.is_err());
+        assert!(
+            matches!(
+                result.unwrap_err(),
+                queue_keeper_core::QueueKeeperError::NotFound { .. }
+            ),
+            "must be NotFound for unknown session"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `get_statistics` reflects stored event count.
+    #[tokio::test]
+    async fn test_get_statistics_counts_stored_events() {
+        let (storage, dir) = make_storage("get-statistics").await;
+        let store = BlobBackedEventStore::new(Arc::clone(&storage));
+
+        // Initially zero events
+        let stats_before = store.get_statistics().await.unwrap();
+        assert_eq!(stats_before.total_events, 0);
+
+        // Store 5 events
+        for _ in 0..5 {
+            let e = WrappedEvent::new(
+                "github".to_string(),
+                "push".to_string(),
+                None,
+                None,
+                serde_json::json!({}),
+            );
+            store_wrapped_event_to_blob(storage.as_ref(), &e)
+                .await
+                .unwrap();
+        }
+
+        let stats_after = store.get_statistics().await.unwrap();
+        assert_eq!(stats_after.total_events, 5);
+        assert!(
+            stats_after.uptime_seconds < 10,
+            "uptime should be very small in tests"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// `store_wrapped_event_to_blob` on a tampered event causes `get_event` to fail
+    /// with `QueueKeeperError::Internal` (wrapping the `ChecksumMismatch`).
+    #[tokio::test]
+    async fn test_get_event_detects_tampered_blob() {
+        use std::io::Write;
+
+        let (storage, dir) = make_storage("get-event-tamper").await;
+        let store = BlobBackedEventStore::new(Arc::clone(&storage));
+
+        let event = WrappedEvent::new(
+            "github".to_string(),
+            "push".to_string(),
+            None,
+            None,
+            serde_json::json!({}),
+        );
+        let event_id = event.event_id;
+
+        store_wrapped_event_to_blob(storage.as_ref(), &event)
+            .await
+            .unwrap();
+
+        // Locate and tamper the blob file on disk
+        let blob_path = event_id.to_blob_path(); // "webhook-payloads/year=.../..."
+        let file_path = dir.join(&blob_path);
+        assert!(file_path.exists(), "blob file must exist");
+
+        let raw = std::fs::read_to_string(&file_path).unwrap();
+        let mut value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        value["payload"]["body"] = serde_json::json!([99u8, 99u8, 99u8]); // corrupt body
+        let tampered = serde_json::to_string_pretty(&value).unwrap();
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&file_path)
+            .unwrap();
+        f.write_all(tampered.as_bytes()).unwrap();
+        drop(f);
+
+        let result = store.get_event(&event_id).await;
+
+        assert!(result.is_err(), "tampered blob must cause an error");
+        // The error should be Internal (wrapping ChecksumMismatch) per map_storage_error
+        assert!(
+            matches!(
+                result.unwrap_err(),
+                queue_keeper_core::QueueKeeperError::Internal { .. }
+            ),
+            "must be Internal error for checksum mismatch"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/crates/queue-keeper-integration-tests/tests/blob_storage.rs
+++ b/crates/queue-keeper-integration-tests/tests/blob_storage.rs
@@ -152,16 +152,23 @@ async fn test_checksum_tamper_detection() {
 
     // Act: Store payload
     let store_result = storage.store_payload(&event_id, &payload).await;
-    assert!(store_result.is_ok(), "Store should succeed: {:?}", store_result.err());
+    assert!(
+        store_result.is_ok(),
+        "Store should succeed: {:?}",
+        store_result.err()
+    );
     let blob_meta = store_result.unwrap();
 
     // Tamper: read the JSON file on disk and replace the stored body bytes
     // with different content (without updating the checksum).
     let blob_file = storage_path.join(&blob_meta.blob_path);
-    assert!(blob_file.exists(), "Blob file must exist at {:?}", blob_file);
+    assert!(
+        blob_file.exists(),
+        "Blob file must exist at {:?}",
+        blob_file
+    );
 
-    let raw_json = std::fs::read_to_string(&blob_file)
-        .expect("Should be able to read blob file");
+    let raw_json = std::fs::read_to_string(&blob_file).expect("Should be able to read blob file");
 
     // Parse, mutate, reserialise — replacing the body but leaving the checksum intact
     let mut stored_value: serde_json::Value =
@@ -171,8 +178,8 @@ async fn test_checksum_tamper_detection() {
     // different bytes to break the checksum.
     stored_value["payload"]["body"] = serde_json::json!([1u8, 2u8, 3u8, 4u8]);
 
-    let tampered_json = serde_json::to_string_pretty(&stored_value)
-        .expect("Re-serialisation should succeed");
+    let tampered_json =
+        serde_json::to_string_pretty(&stored_value).expect("Re-serialisation should succeed");
 
     let mut file = std::fs::OpenOptions::new()
         .write(true)

--- a/crates/queue-keeper-integration-tests/tests/blob_storage.rs
+++ b/crates/queue-keeper-integration-tests/tests/blob_storage.rs
@@ -118,8 +118,15 @@ async fn test_payload_retrieval() {
 /// Verify that checksums detect payload tampering
 ///
 /// Tests Assertion #23: Payload Immutability (tamper detection)
+///
+/// Stores a payload, then directly modifies the stored JSON file on disk to
+/// simulate tampering, and confirms that the next retrieval returns a
+/// `BlobStorageError::ChecksumMismatch`.
 #[tokio::test]
 async fn test_checksum_tamper_detection() {
+    use queue_keeper_core::blob_storage::BlobStorageError;
+    use std::io::Write;
+
     // Arrange
     let storage_path = std::env::temp_dir().join("test-storage-tamper");
     let storage = queue_keeper_core::adapters::filesystem_storage::FilesystemBlobStorage::new(
@@ -129,8 +136,9 @@ async fn test_checksum_tamper_detection() {
     .expect("Failed to create storage");
 
     let event_id = EventId::new();
+    let original_body = Bytes::from("{\"action\":\"opened\"}");
     let payload = WebhookPayload {
-        body: Bytes::from("{\"action\":\"opened\"}"),
+        body: original_body.clone(),
         headers: HashMap::new(),
         metadata: PayloadMetadata {
             event_id,
@@ -144,14 +152,51 @@ async fn test_checksum_tamper_detection() {
 
     // Act: Store payload
     let store_result = storage.store_payload(&event_id, &payload).await;
-    assert!(store_result.is_ok());
+    assert!(store_result.is_ok(), "Store should succeed: {:?}", store_result.err());
+    let blob_meta = store_result.unwrap();
 
-    // Tamper with stored file (modify the body)
-    // Note: This requires finding the stored file and modifying it
-    // For filesystem storage, we'd need to know the path structure
+    // Tamper: read the JSON file on disk and replace the stored body bytes
+    // with different content (without updating the checksum).
+    let blob_file = storage_path.join(&blob_meta.blob_path);
+    assert!(blob_file.exists(), "Blob file must exist at {:?}", blob_file);
 
-    // TODO: Implement file tampering based on storage path structure
-    // Then verify that retrieval detects the tampering
+    let raw_json = std::fs::read_to_string(&blob_file)
+        .expect("Should be able to read blob file");
+
+    // Parse, mutate, reserialise — replacing the body but leaving the checksum intact
+    let mut stored_value: serde_json::Value =
+        serde_json::from_str(&raw_json).expect("Blob should be valid JSON");
+
+    // The body is stored as a byte array (via bytes_serde). Replace it with
+    // different bytes to break the checksum.
+    stored_value["payload"]["body"] = serde_json::json!([1u8, 2u8, 3u8, 4u8]);
+
+    let tampered_json = serde_json::to_string_pretty(&stored_value)
+        .expect("Re-serialisation should succeed");
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&blob_file)
+        .expect("Should be able to open blob file for writing");
+    file.write_all(tampered_json.as_bytes())
+        .expect("Should be able to write tampered content");
+    drop(file);
+
+    // Assert: retrieval detects the tampering via checksum mismatch
+    let retrieve_result = storage.get_payload(&event_id).await;
+
+    assert!(
+        retrieve_result.is_err(),
+        "Retrieval of tampered blob must return an error"
+    );
+    assert!(
+        matches!(
+            retrieve_result.unwrap_err(),
+            BlobStorageError::ChecksumMismatch { .. }
+        ),
+        "Error must be ChecksumMismatch"
+    );
 
     // Cleanup
     let _ = std::fs::remove_dir_all(storage_path);

--- a/crates/queue-keeper-integration-tests/tests/common/mod.rs
+++ b/crates/queue-keeper-integration-tests/tests/common/mod.rs
@@ -694,6 +694,7 @@ pub fn create_test_app_state_with_providers(
         queue_keeper_api::queue_delivery::QueueDeliveryConfig::default(),
         None, // ip_rate_limiter: disabled in unit/integration tests
         None, // admin_api_key: no auth in unit/integration tests
+        None, // event_blob_storage: no event persistence in unit/integration tests
     )
 }
 

--- a/crates/queue-keeper-service/src/main.rs
+++ b/crates/queue-keeper-service/src/main.rs
@@ -15,10 +15,13 @@ mod signature_validator;
 
 use circuit_breaker::queue::{CircuitBreakerQueueClient, CircuitBreakerQueueProvider};
 use queue_keeper_api::{
-    start_server, DefaultEventStore, ProviderId, ProviderRegistry, QueueBackendConfig,
+    start_server, BlobBackedEventStore, ProviderId, ProviderRegistry, QueueBackendConfig,
     ServiceConfig, ServiceError, ServiceHealthChecker,
 };
-use queue_keeper_core::adapters::{memory_key_vault::InMemorySecretCache, AzureKeyVaultProvider};
+use queue_keeper_core::adapters::{
+    memory_key_vault::InMemorySecretCache, AzureKeyVaultProvider, FilesystemBlobStorage,
+};
+use queue_keeper_core::blob_storage::BlobStorage;
 use queue_keeper_core::bot_config::BotConfiguration;
 use queue_keeper_core::key_vault::{KeyVaultConfiguration, KeyVaultProvider, SecretName};
 use queue_keeper_core::webhook::{generic_provider::GenericWebhookProvider, GithubWebhookProvider};
@@ -26,8 +29,9 @@ use queue_runtime::{
     InMemoryConfig, ProviderConfig, QueueClientFactory, QueueConfig, StandardQueueClient,
 };
 use signature_validator::{KeyVaultSignatureValidator, LiteralSignatureValidator};
+use std::path::PathBuf;
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -255,7 +259,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let provider_registry = Arc::new(provider_registry);
     let health_checker = Arc::new(ServiceHealthChecker::new(Arc::clone(&provider_registry)));
-    let event_store = Arc::new(DefaultEventStore);
+
+    // -------------------------------------------------------------------------
+    // Initialise blob storage for persisting processed events.
+    //
+    // Events written here power the /api/events and /api/sessions query
+    // endpoints. The default is filesystem-backed storage at ./data/events
+    // (relative to the working directory). In production you would replace
+    // this with an Azure Blob Storage adapter configured from the azure section
+    // of service.yaml.
+    // -------------------------------------------------------------------------
+    let event_blob_path =
+        std::env::var("QK_EVENT_STORAGE_PATH").unwrap_or_else(|_| "./data/events".to_string());
+
+    let event_blob_storage: Option<Arc<dyn BlobStorage>> =
+        match FilesystemBlobStorage::new(PathBuf::from(&event_blob_path)).await {
+            Ok(storage) => {
+                info!(path = %event_blob_path, "Event blob storage initialised (filesystem)");
+                Some(Arc::new(storage))
+            }
+            Err(e) => {
+                warn!(
+                    path = %event_blob_path,
+                    error = %e,
+                    "Failed to initialise event blob storage; /api/events will return empty results"
+                );
+                None
+            }
+        };
+
+    let event_store: Arc<dyn queue_keeper_api::EventStore> =
+        if let Some(ref storage) = event_blob_storage {
+            Arc::new(BlobBackedEventStore::new(Arc::clone(storage)))
+        } else {
+            Arc::new(queue_keeper_api::DefaultEventStore)
+        };
 
     // -------------------------------------------------------------------------
     // Build queue client from runtime configuration.
@@ -302,6 +340,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         generic_provider_ids,
         Some(queue_client),
         bot_config,
+        event_blob_storage,
     )
     .await
     {


### PR DESCRIPTION
Replaces the stub `DefaultEventStore` with a `BlobBackedEventStore` backed by `FilesystemBlobStorage`, making the `/api/events` and `/api/sessions` query endpoints return real persisted data. Also completes the previously stubbed checksum tamper-detection integration test.

## What Changed

- Added `BlobBackedEventStore` to `responses.rs` implementing all five `EventStore` methods: `list_events` (with filtering and pagination), `get_event`, `list_sessions`, `get_session`, and `get_statistics`.
- Added `store_wrapped_event_to_blob()` helper that serializes a `WrappedEvent` to JSON and writes it to blob storage keyed by the event's own `EventId`.
- Updated the webhook handler to spawn a fire-and-forget task that persists each successfully processed `WrappedEvent` to blob storage.
- Extended `AppState` with an optional `event_blob_storage: Option<Arc<dyn BlobStorage>>` field; `start_server` takes the same parameter.
- Updated `main.rs` to initialize `FilesystemBlobStorage` at `QK_EVENT_STORAGE_PATH` (default `./data/events`) and wire it into `BlobBackedEventStore`. Falls back to the no-op `DefaultEventStore` when storage initialization fails.
- Completed `test_checksum_tamper_detection` in the integration test suite: the test now corrupts the stored JSON body without updating the stored checksum and asserts `BlobStorageError::ChecksumMismatch` is returned on retrieval.

## Why

The `/api/events`, `/api/sessions`, `/api/statistics`, and related endpoints were all backed by `DefaultEventStore`, which returned empty results or `NotFound` for every request. This made the query API non-functional in any deployment. Spec issue #7 identified this as a major gap; issue #15 flagged that the checksum tamper-detection path was exercised by infrastructure code but never validated by a test.

## How

`WrappedEvent` has its own `EventId` (distinct from the raw-payload blob ID generated during `store_raw_payload`). To keep the event query store consistent with the IDs the API returns to callers, `WrappedEvent` blobs are written separately from raw-payload blobs, from the webhook handler, using `wrapped_event.event_id` as the storage key. Loading is lazy: `list_events` and session methods enumerate all blobs and deserialize each in turn, skipping any that cannot be parsed. Checksum validation happens automatically inside `FilesystemBlobStorage::get_payload` on every read, so `get_event` surfaces `ChecksumMismatch` as a `QueueKeeperError::Internal` when a blob has been tampered with.

## Testing Evidence

- **Test Coverage:** Added 10 new unit tests in `responses_tests.rs` covering `BlobBackedEventStore`: round-trip get, not-found errors, list filtering by event type, pagination, session grouping by session ID, `get_session` with correct entity metadata, not-found session, statistics counting, and tamper detection. Completed one previously stubbed integration test (`test_checksum_tamper_detection`) in `blob_storage.rs`.
- **Test Results:** All 180 unit tests pass; `cargo clippy --workspace -- -D warnings` is clean. The pre-existing e2e failure (`test_admin_endpoints_require_auth`) is unrelated to this change and requires a Docker image rebuild.
- **Manual Testing:** `cargo build --workspace` succeeds; full unit test suite run via `cargo test -p queue-keeper-api` and `cargo test -p queue-keeper-core`.

## Reviewer Guidance

- The event blob storage path for `WrappedEvent` blobs is distinct from the raw-payload blob path used by `BlobStorageAdapter`. Verify the path convention in `store_wrapped_event_to_blob` does not collide with raw-payload blobs in shared storage backends.
- Blob persistence from the webhook handler is fire-and-forget: a failure logs a warning but does not affect the HTTP response to GitHub. Review whether silent failure is acceptable or whether a failed write should surface as a 500.
- `load_all_events` (used by `list_sessions`, `get_session`) deserializes every blob on each call with no caching. This is acceptable for current scale but will need optimization at higher event volumes.
- `start_server` now takes 8 parameters, exceeding the default clippy threshold. The lint is suppressed with `#[allow(clippy::too_many_arguments)]` following the same pattern already used on `AppState::new`. Consider grouping parameters into a config struct in a follow-up.
- No breaking changes to the existing HTTP API surface or config file format. The new `QK_EVENT_STORAGE_PATH` environment variable is additive with a safe default of `./data/events`.