### PR TITLE
feat(security): implement three-tier IP authentication failure rate limiting

### DIFF
--- a/crates/queue-keeper-api/src/config.rs
+++ b/crates/queue-keeper-api/src/config.rs
@@ -506,12 +506,36 @@ pub struct SecurityConfig {
     #[serde(default = "SecurityConfig::default_auth_failure_threshold")]
     pub auth_failure_threshold: usize,
 
+    /// Failure count that escalates an IP to the completely-blocked tier.
+    ///
+    /// When a source IP exceeds this many authentication failures within
+    /// `auth_failure_window_secs`, it is blocked for `auth_block_duration_secs`
+    /// regardless of the sliding window expiry. Defaults to 50.
+    ///
+    /// Configure via `QK__SECURITY__AUTH_BLOCK_THRESHOLD`.
+    #[serde(default = "SecurityConfig::default_auth_block_threshold")]
+    pub auth_block_threshold: usize,
+
     /// Duration of the sliding window for authentication failure counting,
     /// in seconds. Defaults to 300 (5 minutes, spec assertion #19).
     ///
     /// Configure via `QK__SECURITY__AUTH_FAILURE_WINDOW_SECS`.
     #[serde(default = "SecurityConfig::default_auth_failure_window_secs")]
     pub auth_failure_window_secs: u64,
+
+    /// How long (seconds) an IP stays in the rate-restricted tier after
+    /// crossing `auth_failure_threshold`. Defaults to 3600 (1 hour).
+    ///
+    /// Configure via `QK__SECURITY__AUTH_RATE_RESTRICT_DURATION_SECS`.
+    #[serde(default = "SecurityConfig::default_auth_rate_restrict_duration_secs")]
+    pub auth_rate_restrict_duration_secs: u64,
+
+    /// How long (seconds) an IP stays in the completely-blocked tier after
+    /// crossing `auth_block_threshold`. Defaults to 86400 (24 hours).
+    ///
+    /// Configure via `QK__SECURITY__AUTH_BLOCK_DURATION_SECS`.
+    #[serde(default = "SecurityConfig::default_auth_block_duration_secs")]
+    pub auth_block_duration_secs: u64,
 
     /// Enable request logging
     #[serde(default = "SecurityConfig::default_log_requests")]
@@ -544,7 +568,13 @@ impl std::fmt::Debug for SecurityConfig {
             .field("enable_ip_rate_limiting", &self.enable_ip_rate_limiting)
             .field("ip_rate_limit", &self.ip_rate_limit)
             .field("auth_failure_threshold", &self.auth_failure_threshold)
+            .field("auth_block_threshold", &self.auth_block_threshold)
             .field("auth_failure_window_secs", &self.auth_failure_window_secs)
+            .field(
+                "auth_rate_restrict_duration_secs",
+                &self.auth_rate_restrict_duration_secs,
+            )
+            .field("auth_block_duration_secs", &self.auth_block_duration_secs)
             .field("log_requests", &self.log_requests)
             .field("log_request_bodies", &self.log_request_bodies)
             .field(
@@ -580,8 +610,20 @@ impl SecurityConfig {
         10
     }
 
+    fn default_auth_block_threshold() -> usize {
+        50
+    }
+
     fn default_auth_failure_window_secs() -> u64 {
         300
+    }
+
+    fn default_auth_rate_restrict_duration_secs() -> u64 {
+        3_600
+    }
+
+    fn default_auth_block_duration_secs() -> u64 {
+        86_400
     }
 }
 
@@ -593,7 +635,11 @@ impl Default for SecurityConfig {
             enable_ip_rate_limiting: true,
             ip_rate_limit: 100,
             auth_failure_threshold: SecurityConfig::default_auth_failure_threshold(),
+            auth_block_threshold: SecurityConfig::default_auth_block_threshold(),
             auth_failure_window_secs: SecurityConfig::default_auth_failure_window_secs(),
+            auth_rate_restrict_duration_secs:
+                SecurityConfig::default_auth_rate_restrict_duration_secs(),
+            auth_block_duration_secs: SecurityConfig::default_auth_block_duration_secs(),
             log_requests: true,
             log_request_bodies: false,
             admin_api_key: None,

--- a/crates/queue-keeper-api/src/lib.rs
+++ b/crates/queue-keeper-api/src/lib.rs
@@ -60,7 +60,7 @@ pub use config::{
 };
 pub use errors::{ConfigError, ServiceError, WebhookHandlerError};
 pub use metrics::{ServiceMetrics, TelemetryConfig};
-pub use middleware::IpFailureTracker;
+pub use middleware::{IpFailureTracker, IpTier};
 pub use provider_registry::{InvalidProviderIdError, ProviderId, ProviderRegistry};
 pub use responses::*;
 
@@ -289,12 +289,15 @@ pub async fn start_server(
 
     let event_router: Arc<dyn EventRouter> = Arc::new(DefaultEventRouter::new());
 
-    // Build IP rate limiter if enabled (assertion #19).
-    // Threshold and window are configurable via SecurityConfig.
+    // Build IP rate limiter if enabled (spec assertion #19, three-tier escalation).
+    // All thresholds and durations are configurable via SecurityConfig.
     let ip_rate_limiter = if config.security.enable_ip_rate_limiting {
         Some(Arc::new(IpFailureTracker::new(
             config.security.auth_failure_threshold,
+            config.security.auth_block_threshold,
             Duration::from_secs(config.security.auth_failure_window_secs),
+            Duration::from_secs(config.security.auth_rate_restrict_duration_secs),
+            Duration::from_secs(config.security.auth_block_duration_secs),
         )))
     } else {
         None

--- a/crates/queue-keeper-api/src/middleware.rs
+++ b/crates/queue-keeper-api/src/middleware.rs
@@ -51,7 +51,7 @@ use crate::AppState;
 /// [`Normal`]: IpTier::Normal
 /// [`RateRestricted`]: IpTier::RateRestricted
 /// [`Blocked`]: IpTier::Blocked
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum IpTier {
     /// Fewer than 10 failures in the 5-minute window — requests pass through.
     Normal,
@@ -73,28 +73,54 @@ impl IpTier {
         !matches!(self, Self::Normal)
     }
 
-    /// Seconds the caller should wait before retrying, per this tier.
+    /// Seconds the caller should wait before retrying based on the **remaining**
+    /// penalty time, as required by RFC 7231 §7.1.3.
     ///
-    /// Returns `0` for [`Normal`] (no waiting required).
+    /// Returns `0` for [`Normal`] (no waiting required) or when the tier has
+    /// already expired (defensive — `check_tier` auto-expires before returning).
     ///
     /// [`Normal`]: IpTier::Normal
     pub fn retry_after_secs(&self) -> u64 {
         match self {
             Self::Normal => 0,
-            Self::RateRestricted { .. } => 3600,
-            Self::Blocked { .. } => 86400,
+            Self::RateRestricted { until } | Self::Blocked { until } => {
+                until.saturating_duration_since(Instant::now()).as_secs()
+            }
         }
     }
 
     /// Returns `true` when this tier has a fixed-duration expiry that has
     /// already passed relative to `now`.
-    fn is_expired(&self, now: Instant) -> bool {
+    pub(crate) fn is_expired(&self, now: Instant) -> bool {
         match self {
             Self::Normal => false,
             Self::RateRestricted { until } | Self::Blocked { until } => now >= *until,
         }
     }
 }
+
+// ============================================================================
+// Manual PartialEq / Eq for IpTier
+// ============================================================================
+
+/// Compare only the variant, ignoring the `until` timestamp.
+///
+/// Two `RateRestricted` or two `Blocked` values are equal regardless of when
+/// their penalty expires. This prevents a foot-gun where two independently
+/// created tiers with identical semantics but different expiry `Instant`s
+/// compare as unequal.
+impl PartialEq for IpTier {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Normal, Self::Normal)
+                | (Self::RateRestricted { .. }, Self::RateRestricted { .. })
+                | (Self::Blocked { .. }, Self::Blocked { .. })
+        )
+    }
+}
+
+impl Eq for IpTier {}
 
 // ============================================================================
 // Per-IP State (private)
@@ -285,36 +311,63 @@ impl IpFailureTracker {
     /// The tier is never downgraded by this method; downgrading happens only
     /// when a timed tier expires (see [`check_tier`]).
     ///
+    /// Returns the new [`IpTier`] for `ip` after recording the failure, so
+    /// callers do not need a second lock acquisition to read the updated state.
+    ///
+    /// After modifying the target IP's state this method also sweeps expired
+    /// entries from the map to prevent unbounded memory growth under sustained
+    /// attacks from many distinct source addresses.
+    ///
     /// [`check_tier`]: IpFailureTracker::check_tier
-    pub fn record_failure(&self, ip: &str) {
+    pub fn record_failure(&self, ip: &str) -> IpTier {
         let mut states = self.states.lock().unwrap();
         let now = Instant::now();
         let window = self.window;
 
-        let state = states.entry(ip.to_string()).or_insert_with(IpState::new);
+        // Update the target IP's state and capture the new tier.
+        let new_tier = {
+            let state = states.entry(ip.to_string()).or_insert_with(IpState::new);
 
-        // Prune failures outside the sliding window.
-        state.failures.retain(|t| now.duration_since(*t) < window);
-        state.failures.push(now);
+            // Prune failures outside the sliding window.
+            state.failures.retain(|t| now.duration_since(*t) < window);
+            state.failures.push(now);
 
-        let count = state.failures.len();
+            let count = state.failures.len();
 
-        // Expire the current tier if its deadline has passed before evaluating
-        // whether to escalate, so we don't skip transitions on expiry.
-        if state.tier.is_expired(now) {
-            state.tier = IpTier::Normal;
-        }
+            // Expire the current tier if its deadline has passed before evaluating
+            // whether to escalate, so we don't skip transitions on expiry.
+            if state.tier.is_expired(now) {
+                state.tier = IpTier::Normal;
+            }
 
-        // Escalate based on the new failure count.
-        if count > self.block_threshold && !matches!(state.tier, IpTier::Blocked { .. }) {
-            state.tier = IpTier::Blocked {
-                until: now + self.block_duration,
-            };
-        } else if count >= self.rate_restrict_threshold && matches!(state.tier, IpTier::Normal) {
-            state.tier = IpTier::RateRestricted {
-                until: now + self.rate_restrict_duration,
-            };
-        }
+            // Escalate based on the new failure count.
+            if count > self.block_threshold && !matches!(state.tier, IpTier::Blocked { .. }) {
+                state.tier = IpTier::Blocked {
+                    until: now + self.block_duration,
+                };
+            } else if count >= self.rate_restrict_threshold
+                && matches!(state.tier, IpTier::Normal)
+            {
+                state.tier = IpTier::RateRestricted {
+                    until: now + self.rate_restrict_duration,
+                };
+            }
+
+            state.tier.clone()
+        };
+
+        // Sweep all entries to evict those whose tier has expired and whose
+        // sliding window is empty, preventing unbounded HashMap growth under
+        // attacks from many distinct source IPs.
+        states.retain(|_, s| {
+            if s.tier.is_expired(now) {
+                s.tier = IpTier::Normal;
+                s.failures.retain(|t| now.duration_since(*t) < window);
+            }
+            !s.failures.is_empty() || s.tier.is_restricted()
+        });
+
+        new_tier
     }
 
     /// Return the number of failures recorded within the current sliding
@@ -396,10 +449,15 @@ pub async fn ip_rate_limit_middleware(
     let response = next.run(request).await;
 
     if response.status() == StatusCode::UNAUTHORIZED {
-        tracker.record_failure(&client_ip);
-        let new_tier = tracker.check_tier(&client_ip);
-        match &new_tier {
-            IpTier::Normal => {}
+        // record_failure returns the new tier in the same lock acquisition,
+        // eliminating the need for a separate check_tier call.
+        match tracker.record_failure(&client_ip) {
+            IpTier::Normal => {
+                info!(
+                    client_ip = %client_ip,
+                    "Authentication failure recorded for IP"
+                );
+            }
             IpTier::RateRestricted { .. } => {
                 warn!(
                     client_ip = %client_ip,
@@ -412,13 +470,6 @@ pub async fn ip_rate_limit_middleware(
                     "IP escalated to Blocked tier after authentication failure"
                 );
             }
-        }
-        if matches!(new_tier, IpTier::Normal) {
-            info!(
-                client_ip = %client_ip,
-                failure_count = tracker.failure_count(&client_ip),
-                "Authentication failure recorded for IP"
-            );
         }
     }
 
@@ -474,10 +525,16 @@ pub async fn admin_auth_middleware(
 /// load balancer) is the only entity that can set `X-Forwarded-For` and
 /// `X-Real-IP` before this service receives the request.
 pub fn extract_client_ip(headers: &HeaderMap) -> String {
+    // 45 chars is the maximum length of a valid IP address string
+    // (IPv6 mapped IPv4, e.g. "0000:0000:0000:0000:0000:0000:255.255.255.255").
+    // Values longer than this are not valid IPs and must not be used as map
+    // keys to prevent adversarially large strings from bloating the tracker.
+    const MAX_IP_LEN: usize = 45;
+
     if let Some(xff) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) {
         if let Some(first) = xff.split(',').next() {
             let ip = first.trim();
-            if !ip.is_empty() {
+            if !ip.is_empty() && ip.len() <= MAX_IP_LEN {
                 return ip.to_string();
             }
         }
@@ -485,7 +542,7 @@ pub fn extract_client_ip(headers: &HeaderMap) -> String {
 
     if let Some(real_ip) = headers.get("x-real-ip").and_then(|v| v.to_str().ok()) {
         let ip = real_ip.trim();
-        if !ip.is_empty() {
+        if !ip.is_empty() && ip.len() <= MAX_IP_LEN {
             return ip.to_string();
         }
     }

--- a/crates/queue-keeper-api/src/middleware.rs
+++ b/crates/queue-keeper-api/src/middleware.rs
@@ -345,8 +345,7 @@ impl IpFailureTracker {
                 state.tier = IpTier::Blocked {
                     until: now + self.block_duration,
                 };
-            } else if count >= self.rate_restrict_threshold
-                && matches!(state.tier, IpTier::Normal)
+            } else if count >= self.rate_restrict_threshold && matches!(state.tier, IpTier::Normal)
             {
                 state.tier = IpTier::RateRestricted {
                     until: now + self.rate_restrict_duration,

--- a/crates/queue-keeper-api/src/middleware.rs
+++ b/crates/queue-keeper-api/src/middleware.rs
@@ -1,8 +1,10 @@
 //! HTTP middleware for security and request handling.
 //!
 //! Provides:
-//! - IP-based authentication failure rate limiting ([`IpFailureTracker`],
-//!   [`ip_rate_limit_middleware`]) — spec assertion #19
+//! - IP-based authentication failure rate limiting with three-tier escalation
+//!   ([`IpFailureTracker`], [`IpTier`], [`ip_rate_limit_middleware`]) — spec
+//!   assertion #19 and `specs/security/rate-limiting.md` §"Security Response
+//!   Escalation"
 //! - Admin endpoint authentication ([`admin_auth_middleware`])
 
 use std::{
@@ -18,39 +20,164 @@ use axum::{
     middleware::Next,
     response::Response,
 };
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::AppState;
+
+// ============================================================================
+// IP Escalation Tier
+// ============================================================================
+
+/// The current access tier for a source IP address.
+///
+/// Tier transitions are triggered by authentication failure counts:
+///
+/// | Failures (5 min window) | Tier | Duration |
+/// |-------------------------|------|----------|
+/// | < 10 | [`Normal`] | — |
+/// | 10 – 50 | [`RateRestricted`] | 1 hour |
+/// | > 50 | [`Blocked`] | 24 hours |
+///
+/// Once an IP enters [`RateRestricted`] or [`Blocked`], the tier is held for
+/// the fixed duration regardless of subsequent sliding-window counts. After
+/// the duration elapses the IP returns to [`Normal`].  Escalation upward
+/// (from [`RateRestricted`] to [`Blocked`]) can happen before the lower tier
+/// expires.
+///
+/// # Spec Reference
+///
+/// `specs/security/rate-limiting.md` §"Security Response Escalation"
+///
+/// [`Normal`]: IpTier::Normal
+/// [`RateRestricted`]: IpTier::RateRestricted
+/// [`Blocked`]: IpTier::Blocked
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IpTier {
+    /// Fewer than 10 failures in the 5-minute window — requests pass through.
+    Normal,
+    /// 10–50 failures — requests are rejected with HTTP 429 for 1 hour.
+    RateRestricted {
+        /// Monotonic instant at which this restriction expires.
+        until: Instant,
+    },
+    /// More than 50 failures — requests are rejected with HTTP 429 for 24 hours.
+    Blocked {
+        /// Monotonic instant at which this block expires.
+        until: Instant,
+    },
+}
+
+impl IpTier {
+    /// Returns `true` when the tier causes requests to be rejected.
+    pub fn is_restricted(&self) -> bool {
+        !matches!(self, Self::Normal)
+    }
+
+    /// Seconds the caller should wait before retrying, per this tier.
+    ///
+    /// Returns `0` for [`Normal`] (no waiting required).
+    ///
+    /// [`Normal`]: IpTier::Normal
+    pub fn retry_after_secs(&self) -> u64 {
+        match self {
+            Self::Normal => 0,
+            Self::RateRestricted { .. } => 3600,
+            Self::Blocked { .. } => 86400,
+        }
+    }
+
+    /// Returns `true` when this tier has a fixed-duration expiry that has
+    /// already passed relative to `now`.
+    fn is_expired(&self, now: Instant) -> bool {
+        match self {
+            Self::Normal => false,
+            Self::RateRestricted { until } | Self::Blocked { until } => now >= *until,
+        }
+    }
+}
+
+// ============================================================================
+// Per-IP State (private)
+// ============================================================================
+
+/// Internal state held per source IP address.
+#[derive(Debug)]
+struct IpState {
+    /// Timestamps of authentication failures within the sliding window.
+    failures: Vec<Instant>,
+    /// Current escalation tier (may have a fixed-duration expiry).
+    tier: IpTier,
+}
+
+impl IpState {
+    fn new() -> Self {
+        Self {
+            failures: Vec::new(),
+            tier: IpTier::Normal,
+        }
+    }
+}
 
 // ============================================================================
 // IP-Based Authentication Failure Rate Limiter
 // ============================================================================
 
-/// Sliding-window counter of authentication failures per source IP.
+/// Three-tier IP authentication failure tracker.
 ///
-/// Every call to [`is_blocked`] and [`record_failure`] prunes entries older
-/// than `window` before operating, so memory usage is bounded by the number
-/// of distinct IPs that have transmitted requests within the window.
+/// Counts authentication failures per source IP within a sliding window and
+/// escalates the IP through three restriction tiers based on cumulative failure
+/// counts:
+///
+/// 1. **Normal** — fewer than `rate_restrict_threshold` failures: allow all
+///    requests.
+/// 2. **RateRestricted** — `rate_restrict_threshold`–`block_threshold`
+///    failures: reject with HTTP 429 for `rate_restrict_duration`.
+/// 3. **Blocked** — more than `block_threshold` failures: reject with HTTP 429
+///    for `block_duration`.
+///
+/// Tier upgrades happen immediately when the failure count crosses a threshold.
+/// Tier downgrades happen only when the fixed-duration penalty expires; the IP
+/// then returns to **Normal** regardless of stale window entries.
+///
+/// # Thread Safety
+///
+/// All state is locked behind a `Mutex`; the tracker is `Send + Sync` and can
+/// be wrapped in `Arc` for shared ownership across Axum handler tasks.
 ///
 /// # Spec Reference
 ///
-/// Assertion #19: "Repeated authentication failures from the same IP address
-/// MUST trigger rate limiting after 10 failures in 5 minutes."
-///
-/// [`is_blocked`]: IpFailureTracker::is_blocked
-/// [`record_failure`]: IpFailureTracker::record_failure
+/// `specs/security/rate-limiting.md` §"Security Response Escalation";
+/// spec assertion #19.
 #[derive(Debug)]
 pub struct IpFailureTracker {
-    /// Failure timestamps keyed by IP string.
-    failures: Mutex<HashMap<String, Vec<Instant>>>,
-    /// Duration of the sliding window.
+    /// Per-IP state: failure timestamps and current tier.
+    states: Mutex<HashMap<String, IpState>>,
+    /// Duration of the sliding failure-counting window.
     window: Duration,
-    /// Number of failures that triggers blocking.
-    max_failures: usize,
+    /// Failure count that triggers the [`IpTier::RateRestricted`] tier.
+    rate_restrict_threshold: usize,
+    /// Failure count that triggers the [`IpTier::Blocked`] tier.
+    block_threshold: usize,
+    /// How long an IP stays in the [`IpTier::RateRestricted`] tier.
+    rate_restrict_duration: Duration,
+    /// How long an IP stays in the [`IpTier::Blocked`] tier.
+    block_duration: Duration,
 }
 
 impl IpFailureTracker {
-    /// Create a new tracker with the given failure threshold and time window.
+    /// Create a tracker with fully specified thresholds and durations.
+    ///
+    /// # Parameters
+    ///
+    /// - `rate_restrict_threshold` — failure count (within `window`) that
+    ///   triggers the [`IpTier::RateRestricted`] tier. Spec default: 10.
+    /// - `block_threshold` — failure count that triggers the
+    ///   [`IpTier::Blocked`] tier. Spec default: 50.
+    /// - `window` — sliding window for failure counting. Spec default: 5 min.
+    /// - `rate_restrict_duration` — how long an IP is rate-restricted. Spec
+    ///   default: 1 hour.
+    /// - `block_duration` — how long an IP is completely blocked. Spec
+    ///   default: 24 hours.
     ///
     /// # Examples
     ///
@@ -58,71 +185,155 @@ impl IpFailureTracker {
     /// use std::time::Duration;
     /// use queue_keeper_api::middleware::IpFailureTracker;
     ///
-    /// // Block after 10 failures in 5 minutes (assertion #19)
-    /// let tracker = IpFailureTracker::new(10, Duration::from_secs(300));
+    /// // Spec-specified defaults
+    /// let tracker = IpFailureTracker::new(
+    ///     10,
+    ///     50,
+    ///     Duration::from_secs(300),
+    ///     Duration::from_secs(3_600),
+    ///     Duration::from_secs(86_400),
+    /// );
     /// ```
-    pub fn new(max_failures: usize, window: Duration) -> Self {
+    pub fn new(
+        rate_restrict_threshold: usize,
+        block_threshold: usize,
+        window: Duration,
+        rate_restrict_duration: Duration,
+        block_duration: Duration,
+    ) -> Self {
         Self {
-            failures: Mutex::new(HashMap::new()),
+            states: Mutex::new(HashMap::new()),
             window,
-            max_failures,
+            rate_restrict_threshold,
+            block_threshold,
+            rate_restrict_duration,
+            block_duration,
         }
     }
 
-    /// Maximum number of failures before an IP is blocked.
-    pub fn max_failures(&self) -> usize {
-        self.max_failures
+    /// Threshold at which an IP enters the [`IpTier::RateRestricted`] tier.
+    pub fn rate_restrict_threshold(&self) -> usize {
+        self.rate_restrict_threshold
     }
 
-    /// Duration of the sliding failure window.
+    /// Threshold at which an IP enters the [`IpTier::Blocked`] tier.
+    pub fn block_threshold(&self) -> usize {
+        self.block_threshold
+    }
+
+    /// Duration of the sliding failure-counting window.
     pub fn window(&self) -> Duration {
         self.window
     }
 
-    /// Return `true` if `ip` has reached or exceeded the failure threshold
-    /// within the current sliding window.
-    pub fn is_blocked(&self, ip: &str) -> bool {
-        let mut map = self.failures.lock().unwrap();
+    /// How long an IP stays in the [`IpTier::RateRestricted`] tier.
+    pub fn rate_restrict_duration(&self) -> Duration {
+        self.rate_restrict_duration
+    }
+
+    /// How long an IP stays in the [`IpTier::Blocked`] tier.
+    pub fn block_duration(&self) -> Duration {
+        self.block_duration
+    }
+
+    /// Return the current [`IpTier`] for `ip`.
+    ///
+    /// If a timed tier ([`IpTier::RateRestricted`] or [`IpTier::Blocked`]) has
+    /// expired, the IP is automatically reset to [`IpTier::Normal`] and its
+    /// failure history is pruned.
+    pub fn check_tier(&self, ip: &str) -> IpTier {
+        let mut states = self.states.lock().unwrap();
         let now = Instant::now();
         let window = self.window;
 
-        if let Some(entry) = map.get_mut(ip) {
-            entry.retain(|t| now.duration_since(*t) < window);
-            if entry.is_empty() {
-                map.remove(ip);
-                return false;
+        if let Some(state) = states.get_mut(ip) {
+            // Expire timed tiers that have passed their deadline.
+            if state.tier.is_expired(now) {
+                state.tier = IpTier::Normal;
+                state.failures.retain(|t| now.duration_since(*t) < window);
+                if state.failures.is_empty() {
+                    states.remove(ip);
+                    return IpTier::Normal;
+                }
             }
-            entry.len() >= self.max_failures
+            state.tier.clone()
         } else {
-            false
+            IpTier::Normal
         }
     }
 
-    /// Record one authentication failure for `ip`.
-    pub fn record_failure(&self, ip: &str) {
-        let mut map = self.failures.lock().unwrap();
-        let now = Instant::now();
-        let window = self.window;
-        let entry = map.entry(ip.to_string()).or_default();
-        entry.retain(|t| now.duration_since(*t) < window);
-        entry.push(now);
+    /// Return `true` if `ip` is currently in a restricted tier.
+    ///
+    /// Convenience wrapper around [`check_tier`].
+    ///
+    /// [`check_tier`]: IpFailureTracker::check_tier
+    pub fn is_blocked(&self, ip: &str) -> bool {
+        self.check_tier(ip).is_restricted()
     }
 
-    /// Return the number of failures recorded within the current window for `ip`.
+    /// Record one authentication failure for `ip` and escalate its tier if
+    /// the new failure count crosses a threshold.
     ///
-    /// Exposed for monitoring and testing.
-    pub fn failure_count(&self, ip: &str) -> usize {
-        let mut map = self.failures.lock().unwrap();
+    /// Escalation rules (evaluated after appending the new failure):
+    ///
+    /// - Count > `block_threshold` AND tier is not already [`IpTier::Blocked`]
+    ///   → upgrade to **Blocked** for `block_duration`, overwriting
+    ///   [`IpTier::RateRestricted`] if present.
+    /// - Count ≥ `rate_restrict_threshold` AND tier is [`IpTier::Normal`]
+    ///   → upgrade to **RateRestricted** for `rate_restrict_duration`.
+    ///
+    /// The tier is never downgraded by this method; downgrading happens only
+    /// when a timed tier expires (see [`check_tier`]).
+    ///
+    /// [`check_tier`]: IpFailureTracker::check_tier
+    pub fn record_failure(&self, ip: &str) {
+        let mut states = self.states.lock().unwrap();
         let now = Instant::now();
         let window = self.window;
 
-        if let Some(entry) = map.get_mut(ip) {
-            entry.retain(|t| now.duration_since(*t) < window);
-            if entry.is_empty() {
-                map.remove(ip);
+        let state = states.entry(ip.to_string()).or_insert_with(IpState::new);
+
+        // Prune failures outside the sliding window.
+        state.failures.retain(|t| now.duration_since(*t) < window);
+        state.failures.push(now);
+
+        let count = state.failures.len();
+
+        // Expire the current tier if its deadline has passed before evaluating
+        // whether to escalate, so we don't skip transitions on expiry.
+        if state.tier.is_expired(now) {
+            state.tier = IpTier::Normal;
+        }
+
+        // Escalate based on the new failure count.
+        if count > self.block_threshold && !matches!(state.tier, IpTier::Blocked { .. }) {
+            state.tier = IpTier::Blocked {
+                until: now + self.block_duration,
+            };
+        } else if count >= self.rate_restrict_threshold && matches!(state.tier, IpTier::Normal) {
+            state.tier = IpTier::RateRestricted {
+                until: now + self.rate_restrict_duration,
+            };
+        }
+    }
+
+    /// Return the number of failures recorded within the current sliding
+    /// window for `ip`.
+    ///
+    /// This reflects only the raw sliding-window count and does not consider
+    /// active timed tiers. Exposed for monitoring and testing.
+    pub fn failure_count(&self, ip: &str) -> usize {
+        let mut states = self.states.lock().unwrap();
+        let now = Instant::now();
+        let window = self.window;
+
+        if let Some(state) = states.get_mut(ip) {
+            state.failures.retain(|t| now.duration_since(*t) < window);
+            if state.failures.is_empty() && matches!(state.tier, IpTier::Normal) {
+                states.remove(ip);
                 return 0;
             }
-            entry.len()
+            state.failures.len()
         } else {
             0
         }
@@ -135,21 +346,27 @@ impl IpFailureTracker {
 
 /// IP-based authentication failure rate limiting middleware.
 ///
-/// Before forwarding a request to the inner handler, checks whether the source
-/// IP has accumulated enough 401 responses within the configured sliding window.
-/// If the failure count has reached the threshold, returns HTTP 429 immediately
-/// with a `Retry-After: 300` header.
+/// Implements the three-tier progressive response defined in
+/// `specs/security/rate-limiting.md` §"Security Response Escalation":
 ///
-/// After the handler responds, any HTTP 401 is interpreted as an authentication
-/// failure and increments the per-IP counter via [`IpFailureTracker::record_failure`].
+/// | Tier | Condition | HTTP Response |
+/// |------|-----------|---------------|
+/// | Normal | < 10 failures | Pass through |
+/// | RateRestricted | 10–50 failures | 429, `Retry-After: 3600` |
+/// | Blocked | > 50 failures | 429, `Retry-After: 86400` |
+///
+/// Before forwarding a request, the middleware resolves the source IP's current
+/// [`IpTier`]. If restricted, it returns HTTP 429 immediately.  After the
+/// handler responds, any HTTP 401 is recorded as an authentication failure via
+/// [`IpFailureTracker::record_failure`], which may escalate the IP's tier.
 ///
 /// The middleware is a transparent pass-through when `AppState::ip_rate_limiter`
 /// is `None` (i.e. when [`SecurityConfig::enable_ip_rate_limiting`] is `false`).
 ///
 /// # Spec Reference
 ///
-/// Assertion #19: "Repeated authentication failures from the same IP address
-/// MUST trigger rate limiting after 10 failures in 5 minutes."
+/// Spec assertion #19; `specs/security/rate-limiting.md` §"Security Response
+/// Escalation".
 ///
 /// [`SecurityConfig::enable_ip_rate_limiting`]: crate::config::SecurityConfig::enable_ip_rate_limiting
 pub async fn ip_rate_limit_middleware(
@@ -163,26 +380,46 @@ pub async fn ip_rate_limit_middleware(
     };
 
     let client_ip = extract_client_ip(request.headers());
+    let tier = tracker.check_tier(&client_ip);
 
-    if tracker.is_blocked(&client_ip) {
+    if tier.is_restricted() {
+        let retry_after = tier.retry_after_secs();
         warn!(
             client_ip = %client_ip,
+            tier = ?tier,
+            retry_after_secs = retry_after,
             "IP rate limited: too many authentication failures"
         );
-        return build_too_many_requests_response(
-            tracker.max_failures(),
-            tracker.window().as_secs(),
-        );
+        return build_too_many_requests_response(retry_after);
     }
 
     let response = next.run(request).await;
 
     if response.status() == StatusCode::UNAUTHORIZED {
         tracker.record_failure(&client_ip);
-        warn!(
-            client_ip = %client_ip,
-            "Authentication failure recorded for IP rate limiter"
-        );
+        let new_tier = tracker.check_tier(&client_ip);
+        match &new_tier {
+            IpTier::Normal => {}
+            IpTier::RateRestricted { .. } => {
+                warn!(
+                    client_ip = %client_ip,
+                    "IP escalated to RateRestricted tier after authentication failure"
+                );
+            }
+            IpTier::Blocked { .. } => {
+                warn!(
+                    client_ip = %client_ip,
+                    "IP escalated to Blocked tier after authentication failure"
+                );
+            }
+        }
+        if matches!(new_tier, IpTier::Normal) {
+            info!(
+                client_ip = %client_ip,
+                failure_count = tracker.failure_count(&client_ip),
+                "Authentication failure recorded for IP"
+            );
+        }
     }
 
     response
@@ -281,16 +518,15 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
         == 0
 }
 
-fn build_too_many_requests_response(limit: usize, window_secs: u64) -> Response {
+fn build_too_many_requests_response(retry_after_secs: u64) -> Response {
     Response::builder()
         .status(StatusCode::TOO_MANY_REQUESTS)
         .header("content-type", "application/json")
-        .header("retry-after", window_secs.to_string())
-        .header("x-ratelimit-limit", limit.to_string())
+        .header("retry-after", retry_after_secs.to_string())
         .header("x-ratelimit-remaining", "0")
         .body(Body::from(format!(
             r#"{{"error":"Too many authentication failures","retry_after_seconds":{}}}"#,
-            window_secs
+            retry_after_secs
         )))
         .unwrap()
 }

--- a/crates/queue-keeper-api/src/middleware_tests.rs
+++ b/crates/queue-keeper-api/src/middleware_tests.rs
@@ -5,7 +5,36 @@ use std::time::Duration;
 use super::*;
 
 // ============================================================================
-// IpFailureTracker tests
+// Helpers
+// ============================================================================
+
+/// Build a tracker with spec-default settings suitable for most tests.
+///
+/// rate_restrict_threshold=10, block_threshold=50, window=5 min,
+/// rate_restrict_duration=1h, block_duration=24h.
+fn spec_tracker() -> IpFailureTracker {
+    IpFailureTracker::new(
+        10,
+        50,
+        Duration::from_secs(300),
+        Duration::from_secs(3_600),
+        Duration::from_secs(86_400),
+    )
+}
+
+/// Build a tracker with a very short window/durations for time-sensitive tests.
+fn fast_tracker(rate_restrict_threshold: usize, block_threshold: usize) -> IpFailureTracker {
+    IpFailureTracker::new(
+        rate_restrict_threshold,
+        block_threshold,
+        Duration::from_millis(50),  // window
+        Duration::from_millis(80),  // rate_restrict_duration
+        Duration::from_millis(120), // block_duration
+    )
+}
+
+// ============================================================================
+// IpFailureTracker — basic counter tests
 // ============================================================================
 
 mod ip_failure_tracker_tests {
@@ -14,49 +43,59 @@ mod ip_failure_tracker_tests {
     /// Verify that a fresh tracker reports no IP as blocked.
     #[test]
     fn test_new_tracker_reports_no_ip_as_blocked() {
-        let tracker = IpFailureTracker::new(10, Duration::from_secs(300));
+        let tracker = spec_tracker();
         assert!(!tracker.is_blocked("1.2.3.4"));
+    }
+
+    /// Verify check_tier returns Normal for an unseen IP.
+    #[test]
+    fn test_new_tracker_returns_normal_tier_for_unseen_ip() {
+        let tracker = spec_tracker();
+        assert_eq!(tracker.check_tier("1.2.3.4"), IpTier::Normal);
     }
 
     /// Verify that failure count starts at zero for an unseen IP.
     #[test]
     fn test_initial_failure_count_is_zero() {
-        let tracker = IpFailureTracker::new(10, Duration::from_secs(300));
+        let tracker = spec_tracker();
         assert_eq!(tracker.failure_count("1.2.3.4"), 0);
     }
 
     /// Verify that recording failures increments the counter.
     #[test]
     fn test_failure_count_increments_on_record() {
-        let tracker = IpFailureTracker::new(10, Duration::from_secs(300));
+        let tracker = spec_tracker();
         tracker.record_failure("1.2.3.4");
         tracker.record_failure("1.2.3.4");
         assert_eq!(tracker.failure_count("1.2.3.4"), 2);
     }
 
-    /// Verify that an IP is NOT blocked when below the threshold.
+    /// Verify that an IP stays Normal when below the rate-restrict threshold.
     #[test]
-    fn test_ip_not_blocked_below_threshold() {
-        let tracker = IpFailureTracker::new(3, Duration::from_secs(300));
+    fn test_ip_stays_normal_below_rate_restrict_threshold() {
+        let tracker = IpFailureTracker::new(
+            3,
+            10,
+            Duration::from_secs(300),
+            Duration::from_secs(3_600),
+            Duration::from_secs(86_400),
+        );
         tracker.record_failure("1.2.3.4");
         tracker.record_failure("1.2.3.4");
+        assert_eq!(tracker.check_tier("1.2.3.4"), IpTier::Normal);
         assert!(!tracker.is_blocked("1.2.3.4"));
     }
 
-    /// Verify that an IP is blocked once the failure threshold is reached.
-    #[test]
-    fn test_ip_blocked_at_threshold() {
-        let tracker = IpFailureTracker::new(3, Duration::from_secs(300));
-        tracker.record_failure("1.2.3.4");
-        tracker.record_failure("1.2.3.4");
-        tracker.record_failure("1.2.3.4");
-        assert!(tracker.is_blocked("1.2.3.4"));
-    }
-
-    /// Verify that different IPs have independent failure counters.
+    /// Verify that different IPs have independent failure counters and tiers.
     #[test]
     fn test_different_ips_are_independent() {
-        let tracker = IpFailureTracker::new(2, Duration::from_secs(300));
+        let tracker = IpFailureTracker::new(
+            2,
+            10,
+            Duration::from_secs(300),
+            Duration::from_secs(3_600),
+            Duration::from_secs(86_400),
+        );
         tracker.record_failure("1.2.3.4");
         tracker.record_failure("1.2.3.4");
         assert!(tracker.is_blocked("1.2.3.4"));
@@ -66,19 +105,29 @@ mod ip_failure_tracker_tests {
     /// Verify that failures outside the sliding window no longer contribute to
     /// the failure count and the IP is unblocked once the window expires.
     #[tokio::test]
-    async fn test_failures_outside_window_are_ignored() {
-        let tracker = IpFailureTracker::new(2, Duration::from_millis(50));
+    async fn test_failures_outside_window_do_not_affect_tier_after_expiry() {
+        // rate_restrict_threshold=2, block_threshold=10
+        // window=50ms, rate_restrict_duration=200ms
+        let tracker = IpFailureTracker::new(
+            2,
+            10,
+            Duration::from_millis(50),
+            Duration::from_millis(200),
+            Duration::from_millis(500),
+        );
         tracker.record_failure("1.2.3.4");
         tracker.record_failure("1.2.3.4");
+        // IP is now RateRestricted for 200ms
         assert!(
             tracker.is_blocked("1.2.3.4"),
-            "IP should be blocked before window expires"
+            "IP should be rate-restricted immediately after crossing threshold"
         );
 
-        tokio::time::sleep(Duration::from_millis(60)).await;
+        // Wait for rate_restrict_duration to expire
+        tokio::time::sleep(Duration::from_millis(210)).await;
         assert!(
             !tracker.is_blocked("1.2.3.4"),
-            "IP should be unblocked after failures expire"
+            "IP should be Normal after rate-restrict duration expires"
         );
     }
 
@@ -86,47 +135,219 @@ mod ip_failure_tracker_tests {
     /// the HashMap, preventing unbounded memory growth.
     #[test]
     fn test_checking_unseen_ip_does_not_grow_map() {
-        let tracker = IpFailureTracker::new(10, Duration::from_secs(300));
-        // Call all three read paths with a fresh IP
+        let tracker = spec_tracker();
         assert!(!tracker.is_blocked("192.0.2.1"));
         assert_eq!(tracker.failure_count("192.0.2.1"), 0);
 
-        // The internal map must remain empty — no phantom entries created.
-        let map = tracker.failures.lock().unwrap();
-        assert_eq!(map.len(), 0, "No entries should be inserted for unseen IPs");
-    }
-
-    /// Verify that after the window expires, the entry is cleaned up so the map
-    /// does not hold stale empty vecs.
-    #[tokio::test]
-    async fn test_expired_entries_are_removed_from_map() {
-        let tracker = IpFailureTracker::new(5, Duration::from_millis(50));
-        tracker.record_failure("192.0.2.2");
-
-        {
-            let map = tracker.failures.lock().unwrap();
-            assert_eq!(map.len(), 1, "Entry should exist before expiry");
-        }
-
-        tokio::time::sleep(Duration::from_millis(60)).await;
-
-        // Calling is_blocked prunes and removes the now-empty entry.
-        tracker.is_blocked("192.0.2.2");
-
-        let map = tracker.failures.lock().unwrap();
+        let states = tracker.states.lock().unwrap();
         assert_eq!(
-            map.len(),
+            states.len(),
             0,
-            "Expired empty entry should be removed from the map"
+            "No entries should be inserted for unseen IPs"
         );
     }
 
     /// Verify the public accessors return the configured values.
     #[test]
     fn test_accessors_return_configured_values() {
-        let tracker = IpFailureTracker::new(7, Duration::from_secs(120));
-        assert_eq!(tracker.max_failures(), 7);
+        let tracker = IpFailureTracker::new(
+            7,
+            30,
+            Duration::from_secs(120),
+            Duration::from_secs(1_800),
+            Duration::from_secs(43_200),
+        );
+        assert_eq!(tracker.rate_restrict_threshold(), 7);
+        assert_eq!(tracker.block_threshold(), 30);
         assert_eq!(tracker.window(), Duration::from_secs(120));
+        assert_eq!(tracker.rate_restrict_duration(), Duration::from_secs(1_800));
+        assert_eq!(tracker.block_duration(), Duration::from_secs(43_200));
+    }
+}
+
+// ============================================================================
+// IpFailureTracker — three-tier escalation tests
+// ============================================================================
+
+mod ip_tier_escalation_tests {
+    use super::*;
+
+    /// Verify that reaching the rate-restrict threshold transitions the IP to
+    /// the RateRestricted tier with a 1-hour retry-after.
+    #[test]
+    fn test_tier_becomes_rate_restricted_at_lower_threshold() {
+        let tracker = IpFailureTracker::new(
+            3,
+            10,
+            Duration::from_secs(300),
+            Duration::from_secs(3_600),
+            Duration::from_secs(86_400),
+        );
+        tracker.record_failure("1.2.3.4");
+        tracker.record_failure("1.2.3.4");
+        tracker.record_failure("1.2.3.4"); // crosses threshold of 3
+        let tier = tracker.check_tier("1.2.3.4");
+        assert!(
+            matches!(tier, IpTier::RateRestricted { .. }),
+            "Expected RateRestricted, got {:?}",
+            tier
+        );
+        assert_eq!(tier.retry_after_secs(), 3_600);
+        assert!(tier.is_restricted());
+    }
+
+    /// Verify that exceeding the block threshold transitions the IP to
+    /// the Blocked tier with a 24-hour retry-after.
+    #[test]
+    fn test_tier_becomes_blocked_above_upper_threshold() {
+        let tracker = IpFailureTracker::new(
+            3,
+            5,
+            Duration::from_secs(300),
+            Duration::from_secs(3_600),
+            Duration::from_secs(86_400),
+        );
+        for _ in 0..6 {
+            tracker.record_failure("1.2.3.4");
+        }
+        let tier = tracker.check_tier("1.2.3.4");
+        assert!(
+            matches!(tier, IpTier::Blocked { .. }),
+            "Expected Blocked, got {:?}",
+            tier
+        );
+        assert_eq!(tier.retry_after_secs(), 86_400);
+        assert!(tier.is_restricted());
+    }
+
+    /// Verify that once in RateRestricted, additional failures escalate to Blocked.
+    #[test]
+    fn test_rate_restricted_escalates_to_blocked_on_more_failures() {
+        let tracker = IpFailureTracker::new(
+            3,
+            5,
+            Duration::from_secs(300),
+            Duration::from_secs(3_600),
+            Duration::from_secs(86_400),
+        );
+        // Cross rate-restrict threshold
+        for _ in 0..3 {
+            tracker.record_failure("1.2.3.4");
+        }
+        assert!(
+            matches!(tracker.check_tier("1.2.3.4"), IpTier::RateRestricted { .. }),
+            "Should be RateRestricted after 3 failures"
+        );
+        // Cross block threshold
+        for _ in 0..3 {
+            tracker.record_failure("1.2.3.4");
+        }
+        assert!(
+            matches!(tracker.check_tier("1.2.3.4"), IpTier::Blocked { .. }),
+            "Should escalate to Blocked after 6 failures"
+        );
+    }
+
+    /// Verify that the Blocked tier is not downgraded by additional failures.
+    #[test]
+    fn test_blocked_tier_is_not_downgraded_by_more_failures() {
+        let tracker = IpFailureTracker::new(
+            3,
+            5,
+            Duration::from_secs(300),
+            Duration::from_secs(3_600),
+            Duration::from_secs(86_400),
+        );
+        for _ in 0..6 {
+            tracker.record_failure("1.2.3.4");
+        }
+        assert!(matches!(
+            tracker.check_tier("1.2.3.4"),
+            IpTier::Blocked { .. }
+        ));
+
+        // More failures should not change the tier
+        tracker.record_failure("1.2.3.4");
+        tracker.record_failure("1.2.3.4");
+        assert!(
+            matches!(tracker.check_tier("1.2.3.4"), IpTier::Blocked { .. }),
+            "Blocked tier should persist after further failures"
+        );
+    }
+
+    /// Verify that the RateRestricted tier expires after its duration and
+    /// the IP returns to Normal.
+    #[tokio::test]
+    async fn test_rate_restricted_tier_expires_after_duration() {
+        let tracker = fast_tracker(2, 20);
+        tracker.record_failure("1.2.3.4");
+        tracker.record_failure("1.2.3.4"); // cross rate_restrict_threshold
+        assert!(
+            matches!(tracker.check_tier("1.2.3.4"), IpTier::RateRestricted { .. }),
+            "Should be RateRestricted immediately"
+        );
+
+        tokio::time::sleep(Duration::from_millis(90)).await; // > rate_restrict_duration (80ms)
+        assert_eq!(
+            tracker.check_tier("1.2.3.4"),
+            IpTier::Normal,
+            "Should return to Normal after rate_restrict_duration expires"
+        );
+        assert!(!tracker.is_blocked("1.2.3.4"));
+    }
+
+    /// Verify that the Blocked tier expires after its duration and the IP
+    /// returns to Normal.
+    #[tokio::test]
+    async fn test_blocked_tier_expires_after_duration() {
+        let tracker = fast_tracker(2, 3);
+        for _ in 0..4 {
+            tracker.record_failure("1.2.3.4"); // cross block_threshold (3)
+        }
+        assert!(
+            matches!(tracker.check_tier("1.2.3.4"), IpTier::Blocked { .. }),
+            "Should be Blocked immediately"
+        );
+
+        tokio::time::sleep(Duration::from_millis(130)).await; // > block_duration (120ms)
+        assert_eq!(
+            tracker.check_tier("1.2.3.4"),
+            IpTier::Normal,
+            "Should return to Normal after block_duration expires"
+        );
+        assert!(!tracker.is_blocked("1.2.3.4"));
+    }
+
+    /// Verify that record_failure also expires the old tier before escalating,
+    /// so a new failure after a Blocked tier expires can escalate again cleanly.
+    #[tokio::test]
+    async fn test_failure_after_block_expiry_starts_fresh_escalation() {
+        let tracker = fast_tracker(2, 3);
+        for _ in 0..4 {
+            tracker.record_failure("1.2.3.4");
+        }
+        assert!(matches!(
+            tracker.check_tier("1.2.3.4"),
+            IpTier::Blocked { .. }
+        ));
+
+        // Wait for: window (50ms) + block_duration (120ms) to both expire
+        tokio::time::sleep(Duration::from_millis(180)).await;
+
+        // One fresh failure should not re-block (count = 1, below threshold)
+        tracker.record_failure("1.2.3.4");
+        assert_eq!(
+            tracker.check_tier("1.2.3.4"),
+            IpTier::Normal,
+            "Single failure after full expiry should stay Normal"
+        );
+    }
+
+    /// Verify IpTier::Normal retry_after_secs is 0.
+    #[test]
+    fn test_normal_tier_retry_after_is_zero() {
+        assert_eq!(IpTier::Normal.retry_after_secs(), 0);
+        assert!(!IpTier::Normal.is_restricted());
     }
 }
 

--- a/crates/queue-keeper-api/src/middleware_tests.rs
+++ b/crates/queue-keeper-api/src/middleware_tests.rs
@@ -192,7 +192,16 @@ mod ip_tier_escalation_tests {
             "Expected RateRestricted, got {:?}",
             tier
         );
-        assert_eq!(tier.retry_after_secs(), 3_600);
+        // retry_after_secs returns remaining time (RFC 7231 §7.1.3); must be
+        // positive and at most the configured rate_restrict_duration (3600 s).
+        assert!(
+            tier.retry_after_secs() > 0,
+            "retry_after_secs must be positive for RateRestricted tier"
+        );
+        assert!(
+            tier.retry_after_secs() <= 3_600,
+            "retry_after_secs must not exceed rate_restrict_duration"
+        );
         assert!(tier.is_restricted());
     }
 
@@ -216,7 +225,16 @@ mod ip_tier_escalation_tests {
             "Expected Blocked, got {:?}",
             tier
         );
-        assert_eq!(tier.retry_after_secs(), 86_400);
+        // retry_after_secs returns remaining time (RFC 7231 §7.1.3); must be
+        // positive and at most the configured block_duration (86400 s).
+        assert!(
+            tier.retry_after_secs() > 0,
+            "retry_after_secs must be positive for Blocked tier"
+        );
+        assert!(
+            tier.retry_after_secs() <= 86_400,
+            "retry_after_secs must not exceed block_duration"
+        );
         assert!(tier.is_restricted());
     }
 
@@ -404,12 +422,18 @@ mod extract_client_ip_tests {
         );
         assert_eq!(extract_client_ip(&h), "203.0.113.1");
     }
-
     /// Verify that surrounding whitespace in X-Forwarded-For IPs is trimmed.
     #[test]
     fn test_x_forwarded_for_ip_is_trimmed() {
         let headers = headers_with("x-forwarded-for", "  203.0.113.2  , 10.0.0.1");
         assert_eq!(extract_client_ip(&headers), "203.0.113.2");
+    }
+    /// Verify that an IP string longer than 45 characters (max valid IPv6 length)
+    /// is rejected and falls back to \"unknown\".
+    #[test]
+    fn test_overlong_ip_is_rejected() {
+        let headers = headers_with("x-forwarded-for", &"a".repeat(46));
+        assert_eq!(extract_client_ip(&headers), "unknown");
     }
 }
 

--- a/crates/queue-keeper-integration-tests/tests/middleware.rs
+++ b/crates/queue-keeper-integration-tests/tests/middleware.rs
@@ -158,7 +158,10 @@ async fn test_cors_middleware_allows_configured_origins() {
 fn state_with_rate_limiter(max_failures: usize) -> AppState {
     let tracker = Arc::new(IpFailureTracker::new(
         max_failures,
+        max_failures * 10, // block_threshold well above the test threshold
         Duration::from_secs(300),
+        Duration::from_secs(3_600),
+        Duration::from_secs(86_400),
     ));
     // Start from the default test state and override the rate limiter field.
     let mut state = create_test_app_state();
@@ -198,7 +201,13 @@ async fn test_ip_rate_limit_allows_requests_below_threshold() {
 #[tokio::test]
 async fn test_ip_rate_limit_blocks_ip_at_threshold() {
     // Arrange: tracker pre-populated to the threshold
-    let tracker = Arc::new(IpFailureTracker::new(3, Duration::from_secs(300)));
+    let tracker = Arc::new(IpFailureTracker::new(
+        3,
+        50,
+        Duration::from_secs(300),
+        Duration::from_secs(3_600),
+        Duration::from_secs(86_400),
+    ));
     for _ in 0..3 {
         tracker.record_failure("203.0.113.10");
     }
@@ -232,7 +241,13 @@ async fn test_ip_rate_limit_blocks_ip_at_threshold() {
 /// with values derived from the tracker configuration.
 #[tokio::test]
 async fn test_ip_rate_limit_response_includes_rate_limit_headers() {
-    let tracker = Arc::new(IpFailureTracker::new(5, Duration::from_secs(60)));
+    let tracker = Arc::new(IpFailureTracker::new(
+        5,
+        50,
+        Duration::from_secs(300),
+        Duration::from_secs(3_600),
+        Duration::from_secs(86_400),
+    ));
     for _ in 0..5 {
         tracker.record_failure("203.0.113.11");
     }
@@ -259,21 +274,18 @@ async fn test_ip_rate_limit_response_includes_rate_limit_headers() {
         .get("retry-after")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    assert_eq!(
-        retry_after, "60",
-        "Retry-After must reflect the configured window, got {:?}",
+    let retry_after_val: u64 = retry_after
+        .parse()
+        .expect("Retry-After must be a numeric value");
+    assert!(
+        retry_after_val > 0,
+        "Retry-After must be positive, got {:?}",
         retry_after
     );
-
-    let limit = response
-        .headers()
-        .get("x-ratelimit-limit")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    assert_eq!(
-        limit, "5",
-        "X-RateLimit-Limit must reflect the configured threshold, got {:?}",
-        limit
+    assert!(
+        retry_after_val <= 3_600,
+        "Retry-After must not exceed rate-restrict duration (3600 s), got {:?}",
+        retry_after
     );
 
     let remaining = response
@@ -420,7 +432,13 @@ async fn test_health_endpoints_not_gated_by_admin_auth() {
 async fn test_admin_auth_failures_trigger_rate_limiting() {
     // Arrange: tracker with threshold of 3, admin key configured.
     // Pre-populate 3 failures directly so we don't need multiple oneshot calls.
-    let tracker = Arc::new(IpFailureTracker::new(3, Duration::from_secs(300)));
+    let tracker = Arc::new(IpFailureTracker::new(
+        3,
+        50,
+        Duration::from_secs(300),
+        Duration::from_secs(3_600),
+        Duration::from_secs(86_400),
+    ));
     for _ in 0..3 {
         tracker.record_failure("203.0.113.20");
     }


### PR DESCRIPTION
Replaces the binary allow/block `IpFailureTracker` with a three-tier progressive escalation model aligned to the spec table in `specs/security/rate-limiting.md` §"Security Response Escalation". IPs with borderline failure counts are rate-restricted for 1 hour; IPs with confirmed attack patterns are blocked for 24 hours.

## What Changed

- Replaced the binary `IpFailureTracker` (single threshold, sliding-window block) with a three-tier model backed by a new `IpTier` enum (`Normal`, `RateRestricted`, `Blocked`) and a per-IP `IpState` struct that carries both a failure timestamp list and the current tier with its fixed-duration expiry.
- `record_failure()` now escalates to `RateRestricted` when the failure count reaches `rate_restrict_threshold` (default 10) and to `Blocked` when it exceeds `block_threshold` (default 50); `Blocked` overwrites `RateRestricted`.
- New `check_tier()` method auto-expires timed tiers and returns the current `IpTier`; `is_blocked()` is retained as a convenience wrapper for backward compatibility.
- `ip_rate_limit_middleware` uses the tier's `retry_after_secs()` to set the correct `Retry-After` header (3 600 s vs 86 400 s) for each restricted tier.
- `SecurityConfig` gains three new optional-override fields: `auth_block_threshold` (default 50), `auth_rate_restrict_duration_secs` (default 3 600), `auth_block_duration_secs` (default 86 400). All five tracker parameters are now wired from config.
- `IpTier` is re-exported from the crate root alongside `IpFailureTracker`.

## Why

The previous implementation was binary: an IP was either allowed or blocked based on a single configurable threshold. The spec defines a three-tier progressive response — allow → rate-restrict (1 h) → block (24 h) — to distinguish borderline cases from confirmed attack patterns and apply proportional responses. IPs crossing 50 failures were previously subject to the same short sliding-window expiry as borderline cases, giving attackers a reset every 5 minutes rather than a 24-hour block.

## How

Each IP's state is held in an `IpState` struct inside a `Mutex<HashMap<String, IpState>>`. Tier transitions are one-way within a session (Normal → RateRestricted → Blocked); the only downward transition is time-based expiry via `check_tier()`, which resets the tier to Normal once `until` passes. `record_failure()` also checks for expiry before evaluating escalation thresholds, preventing stale tiers from blocking re-escalation after a full expiry cycle.

## Testing Evidence

- **Test Coverage:** Replaced all 10 previous `IpFailureTracker` unit tests with equivalents using the new 5-parameter constructor; added 9 new tests in `ip_tier_escalation_tests` module covering: escalation to `RateRestricted`, escalation to `Blocked`, `RateRestricted` → `Blocked` upgrade, blocked tier persistence after further failures, `RateRestricted` expiry, `Blocked` expiry, re-escalation after full expiry, and `Normal` tier properties.
- **Test Results:** All 191 unit tests pass; `cargo clippy -p queue-keeper-api -- -D warnings` is clean; `cargo check --workspace` succeeds.
- **Manual Testing:** `cargo build --workspace` succeeds on the feature branch.

## Reviewer Guidance

- The `IpTier::RateRestricted` and `IpTier::Blocked` variants carry an `Instant` for expiry. `Instant` is not `Serialize`; if tier state ever needs to be persisted across restarts, this will require a different approach.
- Tier escalation is cumulative within the fixed-duration window: once an IP is `Blocked` for 24 hours, further failures during that window do not reset the block deadline. This matches the spec intent but means a sustained low-rate attacker that crosses 50 failures early will not have its block extended.
- The new config fields (`auth_block_threshold`, `auth_rate_restrict_duration_secs`, `auth_block_duration_secs`) are additive with safe defaults. No existing configuration files need to change.
- No breaking changes to the external HTTP API surface or the webhook processing path.