### PR TITLE
fix(ci): install git-cliff via taiki-e/install-action in release-pr workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -48,9 +48,9 @@ jobs:
         run: cargo binstall -y conventional_commits_next_version
 
       - name: Install git-cliff
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@97a5807a604e12de3a13b52d868ebecaeeea757c # v2.75.4
         with:
-          tool: git-cliff
+          tool: git-cliff@2.12.0
 
       - name: Calculate next version
         id: calc_version

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -48,7 +48,9 @@ jobs:
         run: cargo binstall -y conventional_commits_next_version
 
       - name: Install git-cliff
-        run: cargo binstall -y git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
 
       - name: Calculate next version
         id: calc_version


### PR DESCRIPTION
Fixes a `git-cliff: command not found` error in the `release-pr` workflow caused by `cargo binstall` not propagating the installed binary's location to subsequent steps' `$PATH`.

## What Changed

- Replaced `cargo binstall -y git-cliff` with `taiki-e/install-action@v2` (tool: `git-cliff`) in `.github/workflows/release-pr.yml`.

## Why

`cargo binstall` installs binaries to `~/.cargo/bin` but does not append that path to `$GITHUB_PATH`, so the `git-cliff` binary is invisible to later workflow steps. This caused the `Generate changelog` step to fail with `git-cliff: command not found` on every push to `master`.

## How

`taiki-e/install-action` downloads the prebuilt `git-cliff` binary from GitHub Releases and writes its location to `$GITHUB_PATH`, making it available for all subsequent steps without any manual path manipulation.

## Testing Evidence

- **Test Coverage:** CI workflow change; no unit tests applicable.
- **Test Results:** Fix must be validated by triggering the workflow on `master` after merge.
- **Manual Testing:** Reviewed `taiki-e/install-action` documentation confirming it writes to `$GITHUB_PATH`; pattern is consistent with its established use for other tools in the ecosystem.

## Reviewer Guidance

- `conventional_commits_next_version` remains on `cargo binstall` — it was not failing, so it is left unchanged to minimise diff.
- No logic changes; this is a pure installer swap for `git-cliff` only.
- Verify that the `taiki-e/install-action@v2` version pin is acceptable under the project's dependency policy (no SHA pin used — consider pinning to a SHA if policy requires it).
