### PR TITLE
fix(renovate): remove invalid allowedPostUpdateOptions config option

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,7 +64,6 @@
   },
   "prConcurrentLimit": 10,
   "prHourlyLimit": 2,
-  "allowedPostUpdateOptions": [],
   "postUpdateOptions": [],
   "ignoreScripts": true
 }


### PR DESCRIPTION
The `allowedPostUpdateOptions` field is not a valid Renovate repository config option. It does not appear in either the Renovate repository config or self-hosted config documentation. Renovate was raising a config validation error because of this unknown field.

Removing it fixes the validation. The `postUpdateOptions` field (which is valid and was already present) is retained as-is.