### PR TITLE
fix(release): trigger on release/* branch instead of label

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -178,12 +178,25 @@ jobs:
         run: |
           NEXT_VERSION="${{ steps.calc_version.outputs.NEXT_VERSION }}"
 
+          # Read the current version before updating so we can replace it
+          # in the individual crate Cargo.toml path dependency constraints too
+          CURRENT_VERSION=$(grep '^version = "' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "Current workspace version: ${CURRENT_VERSION}"
+
           # Update workspace version in root Cargo.toml
           sed -i "s/^version = .*/version = \"${NEXT_VERSION}\"/" Cargo.toml
 
+          # Update path dependency version constraints in all crate Cargo.toml files.
+          # Each crate that depends on another workspace crate via a path dep has an
+          # explicit version string that must stay in sync with the workspace version;
+          # Cargo enforces this constraint even for local path dependencies.
+          for crate_toml in crates/*/Cargo.toml; do
+            sed -i "s/version = \"${CURRENT_VERSION}\"/version = \"${NEXT_VERSION}\"/g" "${crate_toml}"
+          done
+
           echo "Updated workspace version to ${NEXT_VERSION}"
 
-          # Verify the change
+          # Verify the root change
           grep "^version = " Cargo.toml
 
       - name: Check for existing release PR
@@ -271,8 +284,8 @@ jobs:
             exit 1
           fi
 
-          # Add Cargo.toml and CHANGELOG.md changes
-          git add Cargo.toml CHANGELOG.md
+          # Add Cargo.toml, crate Cargo.toml files, and CHANGELOG.md changes
+          git add Cargo.toml crates/*/Cargo.toml CHANGELOG.md
 
           # Commit if there are changes, otherwise skip
           if git diff --cached --quiet; then

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -288,7 +288,8 @@ jobs:
           git push origin "${BRANCH_NAME}" --force-with-lease
 
       - name: Create or update release PR
-        if: steps.check_changes.outputs.has_changes == 'true' && steps.create_branch.outputs.committed == 'true'
+        if: steps.check_changes.outputs.has_changes == 'true' &&
+          steps.create_branch.outputs.committed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -339,12 +340,12 @@ jobs:
               --title "chore(release): prepare release v${NEXT_VERSION}" \
               --body-file pr_body.md \
               --base master \
-              --head "${BRANCH_NAME}" \
-              --label "release"
+              --head "${BRANCH_NAME}"
           fi
 
       - name: Skip release PR creation (no version file changes)
-        if: steps.check_changes.outputs.has_changes == 'true' && steps.create_branch.outputs.committed == 'false'
+        if: steps.check_changes.outputs.has_changes == 'true' &&
+          steps.create_branch.outputs.committed == 'false'
         run: |
           echo "Cargo.toml already at target version ${{ steps.calc_version.outputs.NEXT_VERSION }}. No PR needed."
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -190,9 +190,21 @@ jobs:
           # Each crate that depends on another workspace crate via a path dep has an
           # explicit version string that must stay in sync with the workspace version;
           # Cargo enforces this constraint even for local path dependencies.
+          #
+          # The sed pattern is anchored to lines that also contain `path =` so that
+          # third-party dependencies that happen to share the same version string are
+          # not accidentally modified.
           for crate_toml in crates/*/Cargo.toml; do
-            sed -i "s/version = \"${CURRENT_VERSION}\"/version = \"${NEXT_VERSION}\"/g" "${crate_toml}"
+            # Two-pass approach: match lines with both `path =` and `version = "OLD"`
+            # and replace only the version portion on those lines.
+            sed -i "/path = /s/version = \"${CURRENT_VERSION}\"/version = \"${NEXT_VERSION}\"/g" "${crate_toml}"
           done
+
+          # Regenerate the lock file so the release branch is self-consistent.
+          # Without this, Cargo.lock would still reference the old version for
+          # workspace path dependencies, causing CI on the release branch to see
+          # a stale lock file.
+          cargo generate-lockfile
 
           echo "Updated workspace version to ${NEXT_VERSION}"
 
@@ -284,8 +296,8 @@ jobs:
             exit 1
           fi
 
-          # Add Cargo.toml, crate Cargo.toml files, and CHANGELOG.md changes
-          git add Cargo.toml crates/*/Cargo.toml CHANGELOG.md
+          # Add Cargo.toml, crate Cargo.toml files, Cargo.lock and CHANGELOG.md changes
+          git add Cargo.toml crates/*/Cargo.toml Cargo.lock CHANGELOG.md
 
           # Commit if there are changes, otherwise skip
           if git diff --cached --quiet; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ permissions:
 jobs:
   release:
     name: Create release and publish artifacts
-    # Only run if PR was merged and has the release label
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    # Only run if PR was merged from a release/* branch
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "queue-keeper-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "queue-keeper-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "queue-keeper-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "queue-keeper-e2e-tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "queue-keeper-integration-tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "queue-keeper-service"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/queue-keeper-api/Cargo.toml
+++ b/crates/queue-keeper-api/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 # Core dependencies
-queue-keeper-core = { path = "../queue-keeper-core", version = "0.1.0" }
+queue-keeper-core = { path = "../queue-keeper-core", version = "0.2.0" }
 queue-runtime = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/queue-keeper-cli/Cargo.toml
+++ b/crates/queue-keeper-cli/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 
 [dependencies]
 # Core dependencies
-queue-keeper-core = { path = "../queue-keeper-core", version = "0.1.0" }
+queue-keeper-core = { path = "../queue-keeper-core", version = "0.2.0" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/queue-keeper-integration-tests/Cargo.toml
+++ b/crates/queue-keeper-integration-tests/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "queue-keeper-integration-tests"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Integration tests for Queue-Keeper API"
 license = "MIT OR Apache-2.0"
 publish = false
 
 [dev-dependencies]
 # Crates under test
-queue-keeper-api = { path = "../queue-keeper-api", version = "0.1.0" }
-queue-keeper-core = { path = "../queue-keeper-core", version = "0.1.0" }
+queue-keeper-api = { path = "../queue-keeper-api", version = "0.2.0" }
+queue-keeper-core = { path = "../queue-keeper-core", version = "0.2.0" }
 queue-runtime = { workspace = true }
 
 # Testing framework

--- a/crates/queue-keeper-service/Cargo.toml
+++ b/crates/queue-keeper-service/Cargo.toml
@@ -14,10 +14,12 @@ description = "HTTP service for receiving GitHub webhooks"
 
 [dependencies]
 # HTTP API library
-queue-keeper-api = { path = "../queue-keeper-api", version = "0.1.0" }
+queue-keeper-api = { path = "../queue-keeper-api", version = "0.2.0" }
 
 # Core dependencies
-queue-keeper-core = { path = "../queue-keeper-core", version = "0.1.0", features = ["azure"] }
+queue-keeper-core = { path = "../queue-keeper-core", version = "0.2.0", features = [
+    "azure",
+] }
 queue-runtime = { workspace = true }
 github-bot-sdk = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
The release label could be silently removed between PR creation and merge, causing the release workflow to be skipped with no error.

Changes:
- release.yml: replace label check with startsWith(head.ref, 'release/')
- release-pr.yml: remove --label 'release' from gh pr create and gh pr edit since the label is no longer used as a trigger